### PR TITLE
Removed obsolte icondusk-e2e version from dusk

### DIFF
--- a/packages/dusk/package.py
+++ b/packages/dusk/package.py
@@ -17,10 +17,6 @@ class Dusk(PythonPackage):
     # old version before _dusk horizon_
     # (put on hold until _dusk horizon_ is over)
     version('master', branch='master')
-    # correct version for the `icondusk-e2e` component
-    # dusk's `icondusk-e2e` branch must always be at or behind `horizon`
-    # they must not ever diverge!
-    version('icondusk-e2e', branch='icondusk-e2e')
     # development version for phase _dusk horizon_
     version('horizon', branch='horizon', preferred=True)
     version('dev-build', branch='master')

--- a/packages/dusk/package.py
+++ b/packages/dusk/package.py
@@ -19,7 +19,7 @@ class Dusk(PythonPackage):
     version('master', branch='master')
     # development version for phase _dusk horizon_
     version('horizon', branch='horizon', preferred=True)
-    version('dev-build', branch='master')
+    version('dev-build', branch='horizon')
 
     extends('python@3.8.0:3.8.999')
 


### PR DESCRIPTION
We discussed that we don't want this version anymore. icondusk-e2e will use the default version (currently `horizon`) and we have to maintain a single version of dusk for both ICON and icondusk-e2e.