### PR TITLE
new variant +zlib_ng for cosmo to allow much faster compression of NetCDF output

### DIFF
--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -235,3 +235,19 @@ Usage (spack edit)
 
   spack edit <package>
 
+Spack load
+----------
+Add package to the user environment. It can be used i. e. to set all runtime paths 
+like `LD_LIBRARY_PATH` as defined in the respective package.
+`More information in the official Spack documentation <https://spack.readthedocs.io/en/latest/command_index.html?highlight=spack%20load#spack-load>`_
+
+Usage (spack load)
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+  
+  spack load <spec>
+
+Options (spack load)
+^^^^^^^^^^^^^^^^^^^^
+* ---first: load the first match if multiple packages match the spec

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -61,6 +61,7 @@ class Cosmo(MakefilePackage):
     depends_on('claw%gcc', when='+claw', type='build')
     depends_on('boost%gcc', when='cosmo_target=gpu ~cppdycore', type='build')
     depends_on('cmake%gcc', type='build')
+    depends_on('zlib_ng +compat', when='+zlib_ng', type='run')
 
 
     # cosmo-dycore dependency
@@ -98,6 +99,7 @@ class Cosmo(MakefilePackage):
     variant('set_version', default=False, description='Pass cosmo tag version to Makefile')
     variant('gt1', default=False, description='Build dycore with gridtools 1.1.3')
     variant('cuda_arch', default='none', description='Build with cuda_arch', values=('70', '60', '37'), multi=False)
+    variant('zlib_ng', default=False, description='Run with faster zlib-implemention for compression of NetCDF output')
 
     conflicts('+claw', when='cosmo_target=cpu')
     conflicts('+pollen', when='@5.05:5.06,master')
@@ -206,6 +208,10 @@ class Cosmo(MakefilePackage):
             if self.mpi_spec.name == 'mpich':
                 claw_flags += ' -D__CRAYXC'
             env.set('CLAWFC_FLAGS', claw_flags)
+
+        # Zlib_ng
+        if '+zlib_ng' in self.spec:
+            env.prepend_path('LD_LIBRARY_PATH',self.spec['zlib_ng'].prefix + '/lib')
 
         # Linker flags
         if self.compiler.name == 'pgi' and '~cppdycore' in self.spec:

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -61,7 +61,7 @@ class Cosmo(MakefilePackage):
     depends_on('claw%gcc', when='+claw', type='build')
     depends_on('boost%gcc', when='cosmo_target=gpu ~cppdycore', type='build')
     depends_on('cmake%gcc', type='build')
-    depends_on('zlib_ng +compat', when='+zlib_ng', type='run')
+    depends_on('zlib_ng +compat', when='+zlib_ng', type=('link','run'))
 
 
     # cosmo-dycore dependency
@@ -208,10 +208,6 @@ class Cosmo(MakefilePackage):
             if self.mpi_spec.name == 'mpich':
                 claw_flags += ' -D__CRAYXC'
             env.set('CLAWFC_FLAGS', claw_flags)
-
-        # Zlib_ng
-        if '+zlib_ng' in self.spec:
-            env.prepend_path('LD_LIBRARY_PATH',self.spec['zlib_ng'].prefix + '/lib')
 
         # Linker flags
         if self.compiler.name == 'pgi' and '~cppdycore' in self.spec:

--- a/packages/zlib_ng/package.py
+++ b/packages/zlib_ng/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ZlibNg(CMakePackage):
+    """zlib replacement with optimizations for next generation systems."""
+
+    homepage = "https://github.com/zlib-ng/zlib-ng"
+    url      = "https://github.com/zlib-ng/zlib-ng/archive/2.0.0.tar.gz"
+
+    version('2.0.0', sha256='86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8')
+
+    variant('compat', default=False, description='Enable compatibility API')
+    variant('opt', default=True, description='Enable optimizations')
+
+    depends_on('cmake@3.5.1:', type='build')
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('ZLIB_COMPAT', 'compat'),
+            self.define_from_variant('WITH_OPTIM', 'opt'),
+        ]
+
+        return args

--- a/packages/zlib_ng/package.py
+++ b/packages/zlib_ng/package.py
@@ -26,3 +26,7 @@ class ZlibNg(CMakePackage):
         ]
 
         return args
+
+    # modify path to replace zlib used in all dependent libraries in any package
+    def setup_run_environment(self,env):
+        env.prepend_path('LD_LIBRARY_PATH',self.spec['zlib_ng'].prefix + '/lib')


### PR DESCRIPTION
This change speeds-up the work done in this PR:
https://github.com/COSMO-ORG/cosmo/pull/405

Using the zlib_nb is about 2x faster the the original zlib.

Making zlib_ng a link-dependency did not work, ldd cosmo still pointed to the systems zlib.
Therefore I went for the run_environment set in zlib_ng package itself.