### PR TITLE
[Icon] make claw optional

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -80,7 +80,8 @@ class Icon(Package):
         if '~skip-config' in self.spec:
             env.set('XML2_ROOT', self.spec['libxml2'].prefix)
             env.set('SERIALBOX2_ROOT',  self.spec['serialbox'].prefix)
-            env.set('CLAW', self.spec['claw'].prefix + '/bin/clawfc')
+            if '+claw' in self.spec:
+                env.set('CLAW', self.spec['claw'].prefix + '/bin/clawfc')
             env.set('ECCODES_ROOT', self.spec['eccodes'].prefix)
 
     def configure_args(self):


### PR DESCRIPTION
Currently it is not able to build Icon without Claw, because in all cases Spack wants to retrieve
the dependency "claw" even for cases with ~claw variant.