### PR TITLE
Replace git error message when fetching cosmo versions

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -37,6 +37,7 @@ class Cosmo(MakefilePackage):
     git      = 'git@github.com:COSMO-ORG/cosmo.git'
     apngit   = 'git@github.com:MeteoSwiss-APN/cosmo.git'
     c2smgit  = 'git@github.com:C2SM-RCM/cosmo.git'
+    testgit  = 'git@github.com:SOME_DUMMY_REPO/cosmo.git'
     maintainers = ['elsagermann']
 
     version('master', branch='master', get_full_repo=True)
@@ -50,6 +51,7 @@ class Cosmo(MakefilePackage):
 
     set_versions(apngit, reg_filter='.*mch.*')
     set_versions(c2smgit)
+    set_versions(testgit)
 
     depends_on('netcdf-fortran +mpi', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -8,20 +8,25 @@ import subprocess, re, itertools, os
 from spack import *
 
 def get_releases(repo):
-        git_obj = subprocess.run(["git","ls-remote","--refs",repo], stdout=subprocess.PIPE)
-        git_tags = [re.match('refs/tags/(.*)', x.decode('utf-8')).group(1) for x in git_obj.stdout.split() if re.match('refs/tags/(.*)', x.decode('utf-8'))]
-        return git_tags
+        git_obj = subprocess.run(["git","ls-remote","--refs",repo], capture_output=True)
+        if git_obj.return_code != 0:
+            print("Warning: no access to {:s} => not fetching versions".format(repo)
+            return []
+        else:
+            git_tags = [re.match('refs/tags/(.*)', x.decode('utf-8')).group(1) for x in git_obj.stdout.split() if re.match('refs/tags/(.*)', x.decode('utf-8'))]
+            return git_tags
 
 def set_versions(repo, reg_filter=None):
     def filterfn(repo_tag):
         return re.match(reg_filter, repo_tag) != None
 
     tags = get_releases(repo)
-    if reg_filter:
-        tags = list(filter(filterfn, tags))
+    if tags:
+        if reg_filter:
+            tags = list(filter(filterfn, tags))
 
-    for tag in tags:
-        version(tag, git=repo, tag=tag, get_full_repo=True)
+        for tag in tags:
+            version(tag, git=repo, tag=tag, get_full_repo=True)
 
 
 class Cosmo(MakefilePackage):

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -10,7 +10,7 @@ from spack import *
 def get_releases(repo):
         git_obj = subprocess.run(["git","ls-remote","--refs",repo], capture_output=True)
         if git_obj.return_code != 0:
-            print("Warning: no access to {:s} => not fetching versions".format(repo)
+            print("Warning: no access to {:s} => not fetching versions".format(repo))
             return []
         else:
             git_tags = [re.match('refs/tags/(.*)', x.decode('utf-8')).group(1) for x in git_obj.stdout.split() if re.match('refs/tags/(.*)', x.decode('utf-8'))]

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -9,8 +9,8 @@ from spack import *
 
 def get_releases(repo):
         git_obj = subprocess.run(["git","ls-remote","--refs",repo], capture_output=True)
-        if git_obj.return_code != 0:
-            print("Warning: no access to {:s} => not fetching versions".format(repo))
+        if git_obj.returncode != 0:
+            print("\nWarning: no access to {:s} => not fetching versions\n".format(repo))
             return []
         else:
             git_tags = [re.match('refs/tags/(.*)', x.decode('utf-8')).group(1) for x in git_obj.stdout.split() if re.match('refs/tags/(.*)', x.decode('utf-8'))]
@@ -37,7 +37,6 @@ class Cosmo(MakefilePackage):
     git      = 'git@github.com:COSMO-ORG/cosmo.git'
     apngit   = 'git@github.com:MeteoSwiss-APN/cosmo.git'
     c2smgit  = 'git@github.com:C2SM-RCM/cosmo.git'
-    testgit  = 'git@github.com:SOME_DUMMY_REPO/cosmo.git'
     maintainers = ['elsagermann']
 
     version('master', branch='master', get_full_repo=True)
@@ -51,7 +50,6 @@ class Cosmo(MakefilePackage):
 
     set_versions(apngit, reg_filter='.*mch.*')
     set_versions(c2smgit)
-    set_versions(testgit)
 
     depends_on('netcdf-fortran +mpi', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))


### PR DESCRIPTION
When fetching versions of cosmo repositories, a confusing git error
message (like fatal ERROR) appears for repos to which the user doesn't
have access. Replace it with a more useful warning.