### PR TITLE
Update compilers and packages for daint

### DIFF
--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -34,23 +34,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-gnu
-    - gcc/8.1.0
-    - cdt/20.11
-    - gcc/8.1.0
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@8.3.0
     paths:
       cc: cc
@@ -85,7 +68,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: intel@19.0.1.144
+    spec: gcc@10.1.0
     paths:
       cc: cc
       cxx: CC
@@ -95,27 +78,10 @@ compilers:
     operating_system: cnl7
     target: any
     modules:
-    - PrgEnv-intel
-    - intel/19.0.1.144
+    - PrgEnv-gnu
+    - gcc/10.1.0
     - cdt/20.11
-    - intel/19.0.1.144
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.1.1.217
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-intel
-    - intel/19.1.1.217
-    - cdt/20.11
-    - intel/19.1.1.217
+    - gcc/10.1.0
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -153,84 +119,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@7.5.0
-    paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: /opt/gcc/8.1.0/bin/gcc
-      cxx: /opt/gcc/8.1.0/bin/g++
-      f77: /opt/gcc/8.1.0/bin/gfortran
-      fc: /opt/gcc/8.1.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.3.0
-    paths:
-      cc: /opt/gcc/8.3.0/bin/gcc
-      cxx: /opt/gcc/8.3.0/bin/g++
-      f77: /opt/gcc/8.3.0/bin/gfortran
-      fc: /opt/gcc/8.3.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.3.0
-    paths:
-      cc: /opt/gcc/9.3.0/bin/gcc
-      cxx: /opt/gcc/9.3.0/bin/g++
-      f77: /opt/gcc/9.3.0/bin/gfortran
-      fc: /opt/gcc/9.3.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.0.1.144
-    paths:
-      cc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icc
-      cxx: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icpc
-      f77: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
-      fc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.1.1.217
-    paths:
-      cc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icc
-      cxx: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icpc
-      f77: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
-      fc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: pgi@20.1
     paths:
       cc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgcc
@@ -241,5 +129,22 @@ compilers:
     operating_system: sles15
     target: x86_64
     modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.0.1.144
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: cnl7
+    target: x86_64
+    modules:
+    - PrgEnv-intel
+    - intel/19.0.1.144
+    - cdt/20.11
+    - intel/19.0.1.144
     environment: {}
     extra_rpaths: []

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -4,7 +4,7 @@ packages:
     all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [gcc@9.3.0, gcc@8.3.0, gcc@8.1.0, pgi@20.1.1, pgi@20.1.0, cce@10.0.2, cce@11.0.0, intel@19.1.1.217, intel@19.0.1.144]
+        compiler: [gcc@9.3.0, gcc@8.3.0, pgi@20.1.1, pgi@20.1.0, cce@11.0.0, cce@10.0.2, intel@19.0.1.144]
         providers:
             mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
@@ -56,8 +56,13 @@ packages:
             cray-libsci@20.06.1%intel: cray-libsci/20.06.1
             cray-libsci@20.06.1%cce:   cray-libsci/20.06.1
             cray-libsci@20.06.1%pgi:   cray-libsci/20.06.1
+            cray-libsci@20.09.1%pgi:   cray-libsci/20.09.1
+            cray-libsci@20.09.1%gcc:   cray-libsci/20.09.1
+            cray-libsci@20.09.1%cce:   cray-libsci/20.09.1
+            cray-libsci@20.09.1%intel: cray-libsci/20.09.1
         paths:
             cray-libsci@20.06.1%cce: /opt/cray/pe/libsci/20.06.1/CRAYCLANG/9.0/x86_64
+            cray-libsci@20.09.1%cce: /opt/cray/pe/libsci/20.09.1/CRAYCLANG/9.0/x86_64
 
     cray-libsci_acc:
         buildable: false
@@ -68,7 +73,7 @@ packages:
             cray-libsci_acc@20.06.1%pgi:   cray-libsci_acc/20.06.1
     cuda:
         modules:
-          cuda@10.2%gcc: cudatoolkit/10.2.89_3.29-7.0.2.1_3.27__g67354b4 
+          cuda@10.2%gcc: cudatoolkit/10.2.89_3.28-2.1__g52c0314
         version: ['10.2']
     curl:
         paths:
@@ -109,10 +114,18 @@ packages:
             hdf5@1.12.0.0%gcc~mpi+hl+fortran:   cray-hdf5/1.12.0.0
             hdf5@1.12.0.0%cce~mpi+hl+fortran:   cray-hdf5/1.12.0.0
             hdf5@1.12.0.0%pgi~mpi+hl+fortran:   cray-hdf5/1.12.0.0
+            hdf5@1.12.0.4%intel~mpi+hl+fortran: cray-hdf5/1.12.0.4
+            hdf5@1.12.0.4%gcc~mpi+hl+fortran:   cray-hdf5/1.12.0.4
+            hdf5@1.12.0.4%cce~mpi+hl+fortran:   cray-hdf5/1.12.0.4
+            hdf5@1.12.0.4%pgi~mpi+hl+fortran:   cray-hdf5/1.12.0.4
             hdf5@1.12.0.0%intel+mpi+hl+fortran: cray-hdf5-parallel/1.12.0.0
             hdf5@1.12.0.0%gcc+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
             hdf5@1.12.0.0%cce+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
             hdf5@1.12.0.0%pgi+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
+            hdf5@1.12.0.4%intel+mpi+hl+fortran: cray-hdf5-parallel/1.12.0.4
+            hdf5@1.12.0.4%gcc+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.4
+            hdf5@1.12.0.4%cce+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.4
+            hdf5@1.12.0.4%pgi+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.4
         paths:
             hdf5@1.12.0.0%cce~mpi+hl: /opt/cray/pe/hdf5/1.12.0.0/CRAYCLANG/9.0
             hdf5@1.12.0.0%cce~mpi+hl+fortran: /opt/cray/pe/hdf5/1.12.0.0/CRAYCLANG/9.0
@@ -157,10 +170,14 @@ packages:
     mpich:
         buildable: false
         modules:
-            mpich@3.2%gcc:   cray-mpich/7.7.15
-            mpich@3.2%intel: cray-mpich/7.7.15
-            mpich@3.2%cce:   cray-mpich/7.7.15
-            mpich@3.2%pgi:   cray-mpich/7.7.15
+            mpich@7.7.15%gcc:   cray-mpich/7.7.15
+            mpich@7.7.15%intel: cray-mpich/7.7.15
+            mpich@7.7.15%cce:   cray-mpich/7.7.15
+            mpich@7.7.15%pgi:   cray-mpich/7.7.15
+            mpich@7.7.17%gcc:   cray-mpich/7.7.17
+            mpich@7.7.17%intel: cray-mpich/7.7.17
+            mpich@7.7.17%cce:   cray-mpich/7.7.17
+            mpich@7.7.17%pgi:   cray-mpich/7.7.17
     netcdf-c:
         buildable: false
         modules:


### PR DESCRIPTION
Similarly to https://github.com/C2SM/spack-c2sm/pull/265, the compiler and packages settings have to be adapted for Piz Daint after the upgrade from 9-10 September 2021.