### PR TITLE
ADD: cce 12.0.2 daint

### DIFF
--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -1,6 +1,6 @@
 compilers:
 - compiler:
-    spec: cce@10.0.2
+    spec: cce@12.0.2
     paths:
       cc: cc
       cxx: CC
@@ -11,7 +11,7 @@ compilers:
     target: any
     modules:
     - PrgEnv-cray
-    - cce/10.0.2
+    - cce/12.0.2
     environment: {}
     extra_rpaths: []
 - compiler:

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -13,7 +13,7 @@ packages:
             blas: [cray-libsci_acc, cray-libsci, intel-mkl]
             scalapack: [cray-libsci_acc, cray-libsci, intel-mkl]
             pkgconfig: [pkg-config]
-        variants: arch=cray-cnl7-haswell
+        arch: cray-cnl7-haswell
     # packages installed by c2sm-spack instance
     cosmo:
       variants: cuda_arch=60 cosmo_target=gpu slave=daint slurm_partition= "normal" slurm_bin= "srun" slurm_opt_nodes= "-n" slurm_nodes= "1"  slurm_opt_account= "-A" slurm_account= "g110" slurm_opt_constraint= "-C" slurm_constraint= "gpu"

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -4,7 +4,7 @@ packages:
     all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [gcc@10.2.0, gcc@9.3.0, gcc@8.3.0, pgi@20.1.1, pgi@20.1.0, pgi@21.3.0, cce@11.0.0, cce@10.0.2, intel@19.0.1.144]
+        compiler: [gcc@10.2.0, gcc@9.3.0, gcc@8.3.0, pgi@20.1.1, pgi@20.1.0, pgi@21.3.0, cce@12.0.2, cce@11.0.0, intel@19.0.1.144]
         providers:
             mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there


### PR DESCRIPTION
Since ICON buildbot is soon going to take cce@12.0.2 as default (2.6.5-rc), I'd like to upgrade our default cray compiler on Daint to point to the same version. Following the discussion on not keeping too many compilers, this PR also get rid of the oldest cray compiler version (cce@10.0.2).