### PR TITLE
[docs] Add fix to docs for `spack install` error

### DIFF
--- a/docs/Install.rst
+++ b/docs/Install.rst
@@ -94,6 +94,24 @@ in order to activate it.
 
     source <spack-installation-directory>/share/spack/setup-env.sh
 
+Error: Broken cache
+""""""""""""""""""""
+(Happening when mixing spack installations and caches)
+
+If ``spack install <package>@<version>%<compiler>`` prints an error message like:
+
+.. code-block:: bash
+
+   ==> Error: 'str' object has no attribute 'get'
+
+you should remove your spack user config scope which is containing the broken cache:
+
+.. code-block:: bash
+
+    rm -rf ~/.spack
+
+Then try again.
+
 Machine specific config files
 ------------------------------
 There is a set of .yaml files that define machine specific things like compilers, modules, preinstalled packages

--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -76,6 +76,22 @@ Options (spack install)
 * --test=root: run package tests during installation for top-level packages (but skip tests for dependencies)
 * --keep-stage: keep all source needed to build the package
 
+Error: Broken cache
+""""""""""""""""""""
+If `spack install <package>@<version>%<compiler>` prints an error message like:
+
+.. code-block:: bash
+
+   ==> Error: 'str' object has no attribute 'get'
+
+you should remove your spack installation:
+
+.. code-block:: bash
+
+    rm -rf ~/.spack
+
+Then try again.
+
 Spack installcosmo
 ------------------
 Installcosmo can only be used to build COSMO. This command will clone, 

--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -77,8 +77,8 @@ Options (spack install)
 * --keep-stage: keep all source needed to build the package
 
 Error: Broken cache
-""""""""""""""""""""
-If `spack install <package>@<version>%<compiler>` prints an error message like:
+^^^^^^^^^^^^^^^^^^^^
+If ``spack install <package>@<version>%<compiler>`` prints an error message like:
 
 .. code-block:: bash
 

--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -76,22 +76,6 @@ Options (spack install)
 * --test=root: run package tests during installation for top-level packages (but skip tests for dependencies)
 * --keep-stage: keep all source needed to build the package
 
-Error: Broken cache
-^^^^^^^^^^^^^^^^^^^^
-If ``spack install <package>@<version>%<compiler>`` prints an error message like:
-
-.. code-block:: bash
-
-   ==> Error: 'str' object has no attribute 'get'
-
-you should remove your spack installation:
-
-.. code-block:: bash
-
-    rm -rf ~/.spack
-
-Then try again.
-
 Spack installcosmo
 ------------------
 Installcosmo can only be used to build COSMO. This command will clone, 


### PR DESCRIPTION
The following error can occur if the cache of the spack installation is somehow broken. Since the error message doesn't point to anything useful, it might be worth to address this in the documentation.
```
spack installcosmo -v cosmo@master%pgi
==> Error: 'str' object has no attribute 'get'
```