### PR TITLE
Fix tests

### DIFF
--- a/test_spack.py
+++ b/test_spack.py
@@ -391,7 +391,7 @@ class SelfTest(unittest.TestCase):
         self.assertFalse(Has_cycle(dependencies))
 
     def test_expansions_is_acyclic(self):
-        self.assertFalse(Has_cycle(dependencies | expansions))
+        self.assertFalse(Has_cycle({**dependencies, **expansions}))
 
     def test_all_dependencies_are_packages(self):
         all_package_names = {case.package_name for case in all_test_cases}
@@ -411,7 +411,7 @@ if __name__ == '__main__':
     ])
     result = unittest.TextTestRunner(verbosity=2).run(suite)
     if not result.wasSuccessful():
-        sys.exit(False)
+        sys.exit(1)
 
     commands = sys.argv[1:]
     sys.argv = [sys.argv[0]]  # unittest needs this

--- a/test_spack.py
+++ b/test_spack.py
@@ -432,7 +432,8 @@ if __name__ == '__main__':
         commands.remove('--tsa')
 
     # configure spack
-    print(f'Configuring spack with upstream {upstream} on machine {machine}.', flush=True)
+    print(f'Configuring spack with upstream {upstream} on machine {machine}.',
+          flush=True)
     subprocess.run(
         f'python ./config.py -m {machine} -i . -r ./spack/etc/spack -p ./spack -s ./spack -u {upstream} -c ./spack-cache',
         check=True,
@@ -443,7 +444,8 @@ if __name__ == '__main__':
     # handles backward compatibility to run any command
     if any(c not in known_commands for c in commands):
         joined_command = ' '.join(commands)
-        print(f'Input contains unknown command. Executing: {joined_command}', flush=True)
+        print(f'Input contains unknown command. Executing: {joined_command}',
+              flush=True)
         run(joined_command)
         sys.exit()
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -404,7 +404,7 @@ if __name__ == '__main__':
     test_loader = unittest.TestLoader()
 
     # Do self-test first to fail fast
-    print('Self-tests:')
+    print('Self-tests:', flush=True)
     suite = unittest.TestSuite([
         test_loader.loadTestsFromTestCase(DAG_Algorithm_Test),
         test_loader.loadTestsFromTestCase(SelfTest)
@@ -432,7 +432,7 @@ if __name__ == '__main__':
         commands.remove('--tsa')
 
     # configure spack
-    print(f'Configuring spack with upstream {upstream} on machine {machine}.')
+    print(f'Configuring spack with upstream {upstream} on machine {machine}.', flush=True)
     subprocess.run(
         f'python ./config.py -m {machine} -i . -r ./spack/etc/spack -p ./spack -s ./spack -u {upstream} -c ./spack-cache',
         check=True,
@@ -443,7 +443,7 @@ if __name__ == '__main__':
     # handles backward compatibility to run any command
     if any(c not in known_commands for c in commands):
         joined_command = ' '.join(commands)
-        print(f'Input contains unknown command. Executing: {joined_command}')
+        print(f'Input contains unknown command. Executing: {joined_command}', flush=True)
         run(joined_command)
         sys.exit()
 
@@ -468,6 +468,6 @@ if __name__ == '__main__':
     ])
 
     # run tests
-    print(f'Testing packages: {packages_to_test}')
+    print(f'Testing packages: {packages_to_test}', flush=True)
     result = unittest.TextTestRunner(verbosity=2).run(suite)
     sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Fixes false positive self-test.
`sys.exit(False) `returns 0.

`z = x | y`
where x and y are dicts requires Python 3.9 ([PEP-584](https://www.python.org/dev/peps/pep-0584/))
This was hidden by the false positive self-tests.

For review:
Look at the Jenkins output and check if the tests ran successfully.