### PR TITLE
Removes warning if version detection can't access repo.

### DIFF
--- a/tools/version_detection.py
+++ b/tools/version_detection.py
@@ -6,8 +6,6 @@ def get_tags(repo):
     git_obj = subprocess.run(["git", "ls-remote", "--refs", repo],
                              capture_output=True)
     if git_obj.returncode != 0:
-        print("\nWarning: no access to {:s} => not fetching versions\n".format(
-            repo))
         return []
     else:
         git_tags = [


### PR DESCRIPTION
This warning caused issues in icon https://github.com/C2SM/spack-c2sm/issues/394.
The idea to warn is good but it creates problems, so it's better to remove the warnings for now.

I don't think this needs any Jenkins testing. Formal review should be sufficient.