### PR TITLE
Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -103,10 +103,7 @@ def main():
 
     if not os.path.isdir(spack_dir):
         print('Cloning spack instance to: ' + spack_dir)
-        cmd = 'git clone {repo} -b {branch} {dest_dir}'.format(
-            repo=spack_repo,
-            branch=args.version,
-            dest_dir=spack_dir)
+        cmd = f'git clone {spack_repo} -b {args.version} {spack_dir}'
         subprocess.run(cmd.split(), check=True)
 
     shutil.copy('./tools/version_detection.py',

--- a/config.py
+++ b/config.py
@@ -59,7 +59,7 @@ def main():
     parser.add_argument('-r',
                         '--reposdir',
                         type=str,
-                        help='repos.yaml install directory')
+                        help='Deprecated and ignored')
     parser.add_argument(
         '-p',
         '--pckgidir',
@@ -113,21 +113,11 @@ def main():
 
     print('Installing mch packages & ' + admin_and_machine + ' config files.')
 
-    if not args.reposdir:
-        args.reposdir = spack_etc
-
-    # installing repos.yaml
-    if not os.path.isdir(args.reposdir):
-        raise OSError(
-            "repository directory requested with -r does not exists: " +
-            args.reposdir)
-
-    print('Installing repos.yaml on ' + args.reposdir)
-    shutil.copy(spack_c2sm_path + '/sysconfigs/repos.yaml', args.reposdir)
-    reposfile = os.path.join(args.reposdir, 'repos.yaml')
-    repos_data = yaml.safe_load(open(reposfile, 'r'))
-    repos_data['repos'] = [spack_c2sm_path]
-    yaml.safe_dump(repos_data, open(reposfile, 'w'), default_flow_style=False)
+    shutil.copy(spack_c2sm_path + '/sysconfigs/repos.yaml', spack_etc + '/')
+    file = os.path.join(spack_etc, 'repos.yaml')
+    data = yaml.safe_load(open(file, 'r'))
+    data['repos'] = [spack_c2sm_path]
+    yaml.safe_dump(data, open(file, 'w'), default_flow_style=False)
 
     # configure config.yaml
 

--- a/config.py
+++ b/config.py
@@ -88,8 +88,10 @@ def main():
     machine = admin_and_machine.replace('admin-', '')
     spack_dir = args.idir + '/spack'
     spack_etc = args.idir + '/spack/etc/spack'
-    package_install_dir = to_spack_abs_path(args.pckgidir or ('/project/g110' if admin else '$SCRATCH'))
-    build_stage_dir = to_spack_abs_path(args.stgidir) + '/spack-stages/' + admin_and_machine
+    package_install_dir = to_spack_abs_path(
+        args.pckgidir or ('/project/g110' if admin else '$SCRATCH'))
+    build_stage_dir = to_spack_abs_path(
+        args.stgidir) + '/spack-stages/' + admin_and_machine
     cache_dir = to_spack_abs_path(args.cacheidir)
 
     print("spack_c2sm_path: " + spack_c2sm_path)
@@ -153,9 +155,12 @@ def main():
     # configure config.yaml
     file = os.path.join(spack_etc, 'config.yaml')
     data = yaml.safe_load(open(file, 'r'))
-    data['config']['install_tree']['root'] = (package_install_dir + '/spack-install/' + machine)
-    data['config']['module_roots']['tcl'] = (package_install_dir + '/modules/' + admin_and_machine)
-    data['config']['source_cache'] = (cache_dir + '/' + machine + '/source_cache')
+    data['config']['install_tree']['root'] = (package_install_dir +
+                                              '/spack-install/' + machine)
+    data['config']['module_roots']['tcl'] = (package_install_dir +
+                                             '/modules/' + admin_and_machine)
+    data['config']['source_cache'] = (cache_dir + '/' + machine +
+                                      '/source_cache')
     data['config']['misc_cache'] = (cache_dir + '/' + machine + '/cache')
     data['config']['build_stage'] = [build_stage_dir]
     data['config']['extensions'] = [spack_c2sm_path + '/tools/spack-scripting']
@@ -165,7 +170,8 @@ def main():
     if args.upstreams == 'ON':
         file = os.path.join(spack_etc, 'upstreams.yaml')
         data = yaml.safe_load(open(file, 'r'))
-        data['upstreams']['spack-instance-1']['install_tree'] = '/project/g110/spack-install/' + machine
+        data['upstreams']['spack-instance-1'][
+            'install_tree'] = '/project/g110/spack-install/' + machine
         yaml.safe_dump(data, open(file, 'w'), default_flow_style=False)
 
     print('Spack successfully installed. \nsource ' + spack_dir +

--- a/config.py
+++ b/config.py
@@ -83,6 +83,25 @@ def main():
     )
     args = parser.parse_args()
 
+    spack_c2sm_path = dir_path
+    admin_and_machine = args.machine
+    admin = ('admin' in admin_and_machine)
+    machine = admin_and_machine.replace('admin-', '')
+    spack_dir = args.idir + '/spack'
+    spack_etc = args.idir + '/spack/etc/spack'
+    package_install_dir = to_spack_abs_path(args.pckgidir or ('/project/g110' if admin else '$SCRATCH'))
+    build_stage_dir = to_spack_abs_path(args.stgidir) + '/spack-stages/' + admin_and_machine
+    cache_dir = to_spack_abs_path(args.cacheidir)
+
+    print("spack_c2sm_path: " + spack_c2sm_path)
+    print("admin_and_machine: " + admin_and_machine)
+    print("machine: " + machine)
+    print("spack_dir: " + spack_dir)
+    print("spack_etc: " + spack_etc)
+    print("package_install_dir: " + package_install_dir)
+    print("build_stage_dir: " + build_stage_dir)
+    print("cache_dir: " + cache_dir)
+
     if not os.path.isdir(args.idir + '/spack'):
         print('Cloning spack instance to: ' + args.idir)
         cmd = 'git clone {repo} -b {branch} {dest_dir}'.format(

--- a/config.py
+++ b/config.py
@@ -12,6 +12,21 @@ spack_version = 'v0.17.0'
 spack_repo = 'https://github.com/spack/spack.git'
 
 
+def to_spack_abs_path(path: str) -> str:
+    # Spack paths support environment variables and `~` in paths, so we need to handle them separately.
+    # (see: https://spack.readthedocs.io/en/latest/configuration.html#config-file-variables )
+
+    # It's enough to check only the start
+    # (environment variables in the middle of a path are fine):
+    if path.startswith(("$", "~")):
+        # We assume environment variables to be absolute.
+        # (we can't really fix them anyways, since they could change)
+        return path
+
+    # convert to absolute path
+    return os.path.realpath(path)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=
@@ -126,20 +141,6 @@ def main():
 
     if not args.cacheidir:
         args.cacheidir = '~/.spack'
-
-    def to_spack_abs_path(path: str) -> str:
-        # Spack paths support environment variables and `~` in paths, so we need to handle them separately.
-        # (see: https://spack.readthedocs.io/en/latest/configuration.html#config-file-variables )
-
-        # It's enough to check only the start
-        # (environment variables in the middle of a path are fine):
-        if path.startswith(("$", "~")):
-            # We assume environment variables to be absolute.
-            # (we can't really fix them anyways, since they could change)
-            return path
-
-        # convert to absolute path
-        return os.path.realpath(path)
 
     config_data['config']['install_tree']['root'] = (
         to_spack_abs_path(args.pckgidir) + '/spack-install/' +

--- a/config.py
+++ b/config.py
@@ -171,8 +171,8 @@ def main():
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
     config_files = ["compilers.yaml", "modules.yaml", "packages.yaml"]
     for afile in config_files:
-        cmd = 'cp ' + spack_c2sm_path + '/sysconfigs/' + machine + '/' + afile + ' ' + spack_etc + '/'
-        subprocess.run(cmd.split(), check=True)
+        shutil.copy(spack_c2sm_path + '/sysconfigs/' + machine + '/' + afile,
+                    spack_etc + '/')
 
     print('Spack successfully installed. \nsource ' + spack_dir +
           '/share/spack/setup-env.sh for setting up the instance.')

--- a/config.py
+++ b/config.py
@@ -108,9 +108,6 @@ def main():
             branch=args.version,
             dest_dir=spack_dir)
         subprocess.run(cmd.split(), check=True)
-        print('Installing custom dev-build command')
-        shutil.copy('./tools/spack-scripting/scripting/cmd/dev_build.py',
-                    spack_dir + '/lib/spack/spack/cmd/')
 
     shutil.copy('./tools/version_detection.py',
                 spack_dir + '/lib/spack/version_detection.py')

--- a/config.py
+++ b/config.py
@@ -65,28 +65,26 @@ def main():
         '--pckgidir',
         type=str,
         help=
-        'Define spack package, modules installation directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack'
+        'Define spack package, modules installation directory. Default: admin; /project/g110, non-admin; $SCRATCH'
     )
     parser.add_argument(
         '-s',
         '--stgidir',
         type=str,
-        help=
-        'Define spack stages directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack'
-    )
+        default='$SCRATCH',
+        help='Define spack stages directory. Default: $SCRATCH')
     parser.add_argument(
         '-c',
         '--cacheidir',
         type=str,
+        default='~/.spack',
         help=
-        'Define spack caches (source and misc)  directories. Default:  ~/.spack/machine/source_cache and ~/.spack/machine/cache'
+        'Define spack caches (source and misc)  directories. Default:  ~/.spack'
     )
     args = parser.parse_args()
 
     if not os.path.isdir(args.idir + '/spack'):
         print('Cloning spack instance to: ' + args.idir)
-        if args.version is None:
-            args.version = spack_version
         cmd = 'git clone {repo} -b {branch} {dest_dir}'.format(
             repo=spack_repo,
             branch=args.version,
@@ -135,12 +133,6 @@ def main():
             args.pckgidir = '/project/g110'
         else:
             args.pckgidir = '$SCRATCH'
-
-    if not args.stgidir:
-        args.stgidir = '$SCRATCH'
-
-    if not args.cacheidir:
-        args.cacheidir = '~/.spack'
 
     config_data['config']['install_tree']['root'] = (
         to_spack_abs_path(args.pckgidir) + '/spack-install/' +

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import sys
 import shutil
 import subprocess
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
+spack_c2sm_path = os.path.dirname(os.path.realpath(__file__))
 
 spack_version = 'v0.17.0'
 spack_repo = 'https://github.com/spack/spack.git'
@@ -36,7 +36,7 @@ def main():
         '-i',
         '--idir',
         type=str,
-        default=dir_path,
+        default=spack_c2sm_path,
         required=True,
         help=
         'Where the Spack instance is installed or you want it to be installed')
@@ -83,7 +83,6 @@ def main():
     )
     args = parser.parse_args()
 
-    spack_c2sm_path = dir_path
     admin_and_machine = args.machine
     admin = ('admin' in admin_and_machine)
     machine = admin_and_machine.replace('admin-', '')
@@ -102,26 +101,26 @@ def main():
     print("build_stage_dir: " + build_stage_dir)
     print("cache_dir: " + cache_dir)
 
-    if not os.path.isdir(args.idir + '/spack'):
-        print('Cloning spack instance to: ' + args.idir)
+    if not os.path.isdir(spack_dir):
+        print('Cloning spack instance to: ' + spack_dir)
         cmd = 'git clone {repo} -b {branch} {dest_dir}'.format(
             repo=spack_repo,
             branch=args.version,
-            dest_dir=os.path.join(args.idir, 'spack'))
+            dest_dir=spack_dir)
         subprocess.run(cmd.split(), check=True)
         print('Installing custom dev-build command')
         shutil.copy('./tools/spack-scripting/scripting/cmd/dev_build.py',
-                    args.idir + '/spack/lib/spack/spack/cmd/')
+                    spack_dir + '/lib/spack/spack/cmd/')
 
     shutil.copy('./tools/version_detection.py',
-                args.idir + '/spack/lib/spack/version_detection.py')
-    sys.path.insert(1, os.path.join(args.idir, 'spack/lib/spack/external'))
+                spack_dir + '/lib/spack/version_detection.py')
+    sys.path.insert(1, os.path.join(spack_dir, 'lib/spack/external'))
     from ruamel import yaml
 
-    print('Installing mch packages & ' + args.machine + ' config files.')
+    print('Installing mch packages & ' + admin_and_machine + ' config files.')
 
     if not args.reposdir:
-        args.reposdir = args.idir + '/spack/etc/spack'
+        args.reposdir = spack_etc
 
     # installing repos.yaml
     if not os.path.isdir(args.reposdir):
@@ -130,57 +129,44 @@ def main():
             args.reposdir)
 
     print('Installing repos.yaml on ' + args.reposdir)
-    shutil.copy(dir_path + '/sysconfigs/repos.yaml', args.reposdir)
+    shutil.copy(spack_c2sm_path + '/sysconfigs/repos.yaml', args.reposdir)
     reposfile = os.path.join(args.reposdir, 'repos.yaml')
     repos_data = yaml.safe_load(open(reposfile, 'r'))
-    repos_data['repos'] = [dir_path]
+    repos_data['repos'] = [spack_c2sm_path]
     yaml.safe_dump(repos_data, open(reposfile, 'w'), default_flow_style=False)
 
     # configure config.yaml
 
     # copy config.yaml file in site scope of spack instance
-    configfile = args.idir + '/spack/etc/spack' + '/config.yaml'
+    configfile = spack_etc + '/config.yaml'
 
     shutil.copy(
-        'sysconfigs/' + args.machine.replace('admin-', '') + '/config.yaml',
+        'sysconfigs/' + machine + '/config.yaml',
         configfile)
 
     config_data = yaml.safe_load(open(configfile, 'r'))
 
-    if not args.pckgidir:
-        if 'admin' in args.machine:
-            args.pckgidir = '/project/g110'
-        else:
-            args.pckgidir = '$SCRATCH'
-
     config_data['config']['install_tree']['root'] = (
-        to_spack_abs_path(args.pckgidir) + '/spack-install/' +
-        args.machine.replace('admin-', ''))
+        package_install_dir + '/spack-install/' + machine)
     config_data['config']['source_cache'] = (
-        to_spack_abs_path(args.cacheidir) + '/' +
-        args.machine.replace('admin-', '') + '/source_cache')
-    config_data['config']['misc_cache'] = (to_spack_abs_path(args.cacheidir) +
-                                           '/' +
-                                           args.machine.replace('admin-', '') +
-                                           '/cache')
-    config_data['config']['build_stage'] = [
-        to_spack_abs_path(args.stgidir) + '/spack-stages/' + args.machine
-    ]
+        cache_dir + '/' + machine + '/source_cache')
+    config_data['config']['misc_cache'] = (cache_dir + '/' + machine + '/cache')
+    config_data['config']['build_stage'] = [build_stage_dir]
     config_data['config']['module_roots']['tcl'] = (
-        to_spack_abs_path(args.pckgidir) + '/modules/' + args.machine)
-    config_data['config']['extensions'] = [dir_path + '/tools/spack-scripting']
+        package_install_dir + '/modules/' + admin_and_machine)
+    config_data['config']['extensions'] = [spack_c2sm_path + '/tools/spack-scripting']
     yaml.safe_dump(config_data,
                    open(configfile, 'w'),
                    default_flow_style=False)
 
     # copy modified upstreams.yaml if not admin
     if args.upstreams == 'ON':
-        upstreamfile = args.idir + '/spack/etc/spack' + '/upstreams.yaml'
+        upstreamfile = spack_etc + '/upstreams.yaml'
         shutil.copy('sysconfigs/upstreams.yaml', upstreamfile)
 
         upstreams_data = yaml.safe_load(open(upstreamfile, 'r'))
         upstreams_data['upstreams']['spack-instance-1']['install_tree'] = '/project/g110/spack-install/' + \
-            args.machine.replace('admin-', '')
+            machine
         yaml.safe_dump(upstreams_data,
                        open(upstreamfile, 'w'),
                        default_flow_style=False)
@@ -188,12 +174,11 @@ def main():
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
     config_files = ["compilers.yaml", "modules.yaml", "packages.yaml"]
     for afile in config_files:
-        cmd = 'cp ' + dir_path + '/sysconfigs/' + args.machine.replace(
-            'admin-', '') + '/' + afile + ' ' + args.idir + '/spack/etc/spack/'
+        cmd = 'cp ' + spack_c2sm_path + '/sysconfigs/' + machine + '/' + afile + ' ' + spack_etc + '/'
         subprocess.run(cmd.split(), check=True)
 
-    print('Spack successfully installed. \nsource ' + args.idir +
-          '/spack/share/spack/setup-env.sh for setting up the instance.')
+    print('Spack successfully installed. \nsource ' + spack_dir +
+          '/share/spack/setup-env.sh for setting up the instance.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a refactoring and each commit is supposed to be a refactoring in itself.
Some of the help texts were misleading me. Also I needed to find out where all the files go. So while learning it, I did a little overhauling.

I think the `--reposdir` needs to be set to default or `/spack/etc/spack` for spack to work, otherwise spack can't find the `repos.yaml`. That's why this argument is now deprecated and ignored. As soon as Jenkins and Buildbot don't use the flag any more it can be removed in the code.