### PR TITLE
Srun one level down

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: '*.log'
+                            archiveArtifacts artifacts: '*.log', allowEmptyArchive: true
                             echo 'Cleaning up workspace'
                             deleteDir() 
                         }
@@ -27,7 +27,7 @@ pipeline {
                     }
                     post {
                         always {
-                            archiveArtifacts artifacts: '*.log'
+                            archiveArtifacts artifacts: '*.log', allowEmptyArchive: true
                             echo 'Cleaning up workspace'
                             deleteDir() 
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
                     steps {
                         sh """
                         module load python/3.7.4
-                        srun -c 16 -t 04:00:00 python test_spack.py --tsa """ + env.ghprbCommentBody
+                        python test_spack.py --tsa """ + env.ghprbCommentBody
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
                     }
                     post {
                         always {
+                            archiveArtifacts artifacts: '*.log'
                             echo 'Cleaning up workspace'
                             deleteDir() 
                         }
@@ -26,6 +27,7 @@ pipeline {
                     }
                     post {
                         always {
+                            archiveArtifacts artifacts: '*.log'
                             echo 'Cleaning up workspace'
                             deleteDir() 
                         }

--- a/docs/PrTesting.rst
+++ b/docs/PrTesting.rst
@@ -1,6 +1,6 @@
 PR testing
 ===================================
-To test a PR create a comment ``launch jenkins [--upstream] [--exclusive] ...``
+To test a PR create a comment ``launch jenkins [--upstream] [--exclusive] [--tsa] [--daint] ...``
 with either
 * a space separated list of predefined commands (see "supported commands")
 or
@@ -8,6 +8,8 @@ or
 
 ``--upstream`` links the instance with the upstream spack-admin instance.
 ``--exclusive`` invokes only tests from the listed commands.
+``--test`` runs tests only on Tsa.
+``--daint`` runs tests only on Piz Daint.
 
 What is tested
 ^^^^^^^^^^^^^^^^

--- a/test_spack.py
+++ b/test_spack.py
@@ -8,12 +8,12 @@ import unittest
 
 all_machines = {'daint', 'tsa'}
 
-
 # For each spack test there should be at least one line of comment stating
 # why this spack command is tested and/or where this spack command is used.
 # Otherwise this may apply:
 # “All Your Tests are Terrible..." - Titus Winters & Hyrum Wright
 # https://www.youtube.com/watch?v=u5senBJUkPc&ab_channel=CppCon
+
 
 class TestCase(unittest.TestCase):
 
@@ -27,7 +27,10 @@ class TestCase(unittest.TestCase):
             if machine == 'tsa':
                 srun = 'srun -c 16 -t 01:00:00'
 
-        subprocess.run(f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log', check=True, shell=True)
+        subprocess.run(
+            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log',
+            check=True,
+            shell=True)
 
     def Srun(self, command: str, cwd='.'):
         return self.Run(command, cwd, parallel=True)
@@ -63,20 +66,24 @@ class CosmoTest(TestCase):
     def test_install_master_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun('spack installcosmo cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
-                )
+            self.Srun(
+                'spack installcosmo cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+            )
         if machine == 'daint':
-            self.Srun('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
-                )
+            self.Srun(
+                'spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
+            )
 
     def test_install_master_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Run('spack installcosmo cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
-                )
+            self.Run(
+                'spack installcosmo cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+            )
         if machine == 'daint':
-            self.Run('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
-                )
+            self.Run(
+                'spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
+            )
 
     # def test_install_test(self):
     #     # TODO: Decide if we want to integrate this test or not. It has been used lately here: From https://github.com/C2SM/spack-c2sm/pull/289
@@ -91,10 +98,12 @@ class CosmoTest(TestCase):
         self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.Srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
+                self.Srun(
+                    'spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
             if machine == 'daint':
-                self.Srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
+                self.Srun(
+                    'spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
@@ -104,10 +113,12 @@ class CosmoTest(TestCase):
         self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.Srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
+                self.Srun(
+                    'spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
             if machine == 'daint':
-                self.Srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
+                self.Srun(
+                    'spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
@@ -115,8 +126,9 @@ class CosmoTest(TestCase):
     def test_install_old_version(self):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
-            self.Srun('spack installcosmo cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
-                )
+            self.Srun(
+                'spack installcosmo cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+            )
 
 
 class CosmoDycoreTest(TestCase):
@@ -204,13 +216,15 @@ class IconTest(TestCase):
 
     def test_install_nwp_gpu_nvidia(self):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimick Buildbot for Tsa)
-        self.Srun('spack install icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
-            )
+        self.Srun(
+            'spack install icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
+        )
 
     def test_install_nwp_cpu_nvidia(self):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimick Buildbot for Tsa)
-        self.Srun('spack install icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
-            )
+        self.Srun(
+            'spack install icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
+        )
 
     # TODO: Reactivate once the test works!
     # def test_devbuild_cpu(self):
@@ -252,7 +266,8 @@ class Int2lmTest(TestCase):
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun('spack install --test=root int2lm@org-master%pgi pollen=False')
+            self.Srun(
+                'spack install --test=root int2lm@org-master%pgi pollen=False')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
@@ -542,7 +557,9 @@ if __name__ == '__main__':
         setup = ''
         if joined_command.startswith('spack'):
             setup = f'source spack/share/spack/setup-env.sh &&'
-        subprocess.run(f'{setup} {joined_command} >> {machine}.log', check=True, shell=True)
+        subprocess.run(f'{setup} {joined_command} >> {machine}.log',
+                       check=True,
+                       shell=True)
         sys.exit()
     else:
         # collect and run tests from all packages selected

--- a/test_spack.py
+++ b/test_spack.py
@@ -463,7 +463,9 @@ class SelfTest(unittest.TestCase):
             for dep in deps:
                 self.assertTrue(dep in all_package_names)
 
+
 class CustomTestSuite(unittest.TestSuite):
+
     def run(self, result, debug=False):
         """
         We override the 'run' routine to support the execution of unittest in parallel
@@ -489,6 +491,7 @@ class CustomTestSuite(unittest.TestSuite):
         return result
 
     async def startRunCase(self, index, test, result):
+
         def _isnotsuite(test):
             "A crude way to tell apart testcases and suites with duck-typing"
             try:
@@ -507,14 +510,15 @@ class CustomTestSuite(unittest.TestSuite):
             self._handleClassSetUp(test, result)
             result._previousTestClass = test.__class__
 
-            if (getattr(test.__class__, '_classSetupFailed', False) or
-                    getattr(result, '_moduleSetUpFailed', False)):
+            if (getattr(test.__class__, '_classSetupFailed', False)
+                    or getattr(result, '_moduleSetUpFailed', False)):
                 return True
 
         await loop.run_in_executor(None, test, result)
 
         if self._cleanup:
             self._removeTestAtIndex(index)
+
 
 if __name__ == '__main__':
     test_loader = unittest.TestLoader()

--- a/test_spack.py
+++ b/test_spack.py
@@ -21,7 +21,7 @@ class TestCase(unittest.TestCase):
     def Run(self, command: str, cwd='.', parallel=False):
         setup = ''
         if command.startswith('spack'):
-            setup = f'source spack/share/spack/setup-env.sh &&'
+            setup = f'source spack/share/spack/setup-env.sh ; '
 
         srun = ''
         if parallel:
@@ -30,7 +30,7 @@ class TestCase(unittest.TestCase):
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} cd {cwd} ; {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -466,8 +466,10 @@ if __name__ == '__main__':
     commands = sys.argv[1:]
     sys.argv = [sys.argv[0]]  # unittest needs this
 
-    commands.remove('launch')
-    commands.remove('jenkins')
+    if 'launch' in commands:
+        commands.remove('launch')
+    if 'jenkins' in commands:
+        commands.remove('jenkins')
 
     upstream = 'OFF'
     if '--upstream' in commands:

--- a/test_spack.py
+++ b/test_spack.py
@@ -30,7 +30,7 @@ class TestCase(unittest.TestCase):
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} cd {cwd} ; {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -27,8 +27,9 @@ class TestCase(unittest.TestCase):
             if machine == 'tsa':
                 srun = 'srun -c 16 -t 01:00:00'
 
+        # 2>>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log',
+            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -27,9 +27,9 @@ class TestCase(unittest.TestCase):
             if machine == 'tsa':
                 srun = 'srun -c 16 -t 01:00:00'
 
-        # 2>>&1 redirects stderr to stdout
+        # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>>&1',
+            f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 import subprocess
 import unittest
+import asyncio
 
 all_machines = {'daint', 'tsa'}
 
@@ -462,6 +463,58 @@ class SelfTest(unittest.TestCase):
             for dep in deps:
                 self.assertTrue(dep in all_package_names)
 
+class CustomTestSuite(unittest.TestSuite):
+    def run(self, result, debug=False):
+        """
+        We override the 'run' routine to support the execution of unittest in parallel
+        :param result:
+        :param debug:
+        :return:
+        """
+        topLevel = False
+        if getattr(result, '_testRunEntered', False) is False:
+            result._testRunEntered = topLevel = True
+        asyncMethod = []
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        for index, test in enumerate(self):
+            asyncMethod.append(self.startRunCase(index, test, result))
+        if asyncMethod:
+            loop.run_until_complete(asyncio.wait(asyncMethod))
+        loop.close()
+        if topLevel:
+            self._tearDownPreviousClass(None, result)
+            self._handleModuleTearDown(result)
+            result._testRunEntered = False
+        return result
+
+    async def startRunCase(self, index, test, result):
+        def _isnotsuite(test):
+            "A crude way to tell apart testcases and suites with duck-typing"
+            try:
+                iter(test)
+            except TypeError:
+                return True
+            return False
+
+        loop = asyncio.get_event_loop()
+        if result.shouldStop:
+            return False
+
+        if _isnotsuite(test):
+            self._tearDownPreviousClass(test, result)
+            self._handleModuleFixture(test, result)
+            self._handleClassSetUp(test, result)
+            result._previousTestClass = test.__class__
+
+            if (getattr(test.__class__, '_classSetupFailed', False) or
+                    getattr(result, '_moduleSetUpFailed', False)):
+                return True
+
+        await loop.run_in_executor(None, test, result)
+
+        if self._cleanup:
+            self._removeTestAtIndex(index)
 
 if __name__ == '__main__':
     test_loader = unittest.TestLoader()
@@ -571,7 +624,7 @@ if __name__ == '__main__':
         sys.exit()
     else:
         # collect and run tests from all packages selected
-        suite = unittest.TestSuite([
+        suite = CustomTestSuite([
             test_loader.loadTestsFromTestCase(case) for case in all_test_cases
             if case.package_name in packages_to_test
             and machine in case.machines

--- a/test_spack.py
+++ b/test_spack.py
@@ -8,21 +8,6 @@ import unittest
 
 all_machines = {'daint', 'tsa'}
 
-def run(command: str, cwd='.', parallel=False):
-    setup = ''
-    if command.startswith('spack'):
-        setup = f'source spack/share/spack/setup-env.sh &&'
-
-    srun = ''
-    if parallel:
-        if machine == 'tsa':
-            srun = 'srun -c 16 -t 01:00:00'
-
-    subprocess.run(f'{setup} cd {cwd} && {srun} {command}', check=True, shell=True)
-
-def srun(command: str, cwd='.'):
-    return run(command, cwd, parallel=True)
-
 
 # For each spack test there should be at least one line of comment stating
 # why this spack command is tested and/or where this spack command is used.
@@ -30,26 +15,43 @@ def srun(command: str, cwd='.'):
 # “All Your Tests are Terrible..." - Titus Winters & Hyrum Wright
 # https://www.youtube.com/watch?v=u5senBJUkPc&ab_channel=CppCon
 
+class TestCase(unittest.TestCase):
 
-class AtlasTest(unittest.TestCase):
+    def Run(self, command: str, cwd='.', parallel=False):
+        setup = ''
+        if command.startswith('spack'):
+            setup = f'source spack/share/spack/setup-env.sh &&'
+
+        srun = ''
+        if parallel:
+            if machine == 'tsa':
+                srun = 'srun -c 16 -t 01:00:00'
+
+        subprocess.run(f'{setup} cd {cwd} && {srun} {command} >> {machine}_{self.package_name}_{self._testMethodName}.log', check=True, shell=True)
+
+    def Srun(self, command: str, cwd='.'):
+        return self.Run(command, cwd, parallel=True)
+
+
+class AtlasTest(TestCase):
     package_name = 'atlas'
     depends_on = {'ecbuild', 'eckit'}
     machines = all_machines
 
 
-class AtlasUtilityTest(unittest.TestCase):
+class AtlasUtilityTest(TestCase):
     package_name = 'atlas_utilities'
     depends_on = {'atlas', 'eckit'}
     machines = all_machines
 
 
-class ClawTest(unittest.TestCase):
+class ClawTest(TestCase):
     package_name = 'claw'
     depends_on = {}
     machines = all_machines
 
 
-class CosmoTest(unittest.TestCase):
+class CosmoTest(TestCase):
     package_name = 'cosmo'
     depends_on = {
         'cuda', 'serialbox', 'libgrib1', 'cosmo-grib-api-definitions',
@@ -61,181 +63,181 @@ class CosmoTest(unittest.TestCase):
     def test_install_master_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            srun('spack installcosmo cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+            self.Srun('spack installcosmo cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
                 )
         if machine == 'daint':
-            srun('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
+            self.Srun('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
                 )
 
     def test_install_master_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            run('spack installcosmo cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+            self.Run('spack installcosmo cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
                 )
         if machine == 'daint':
-            run('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
+            self.Run('spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
                 )
 
     # def test_install_test(self):
     #     # TODO: Decide if we want to integrate this test or not. It has been used lately here: From https://github.com/C2SM/spack-c2sm/pull/289
-    #     srun('spack installcosmo --test=root cosmo@master%pgi')
+    #     self.Srun('spack installcosmo --test=root cosmo@master%pgi')
 
     # def test_install_test_claw(self):
     #     # TODO: Decide if we want to integrate this test or not. It has been used lately here: From https://github.com/C2SM/spack-c2sm/pull/289
-    #     srun('spack installcosmo --test=root cosmo@master%pgi +claw')
+    #     self.Srun('spack installcosmo --test=root cosmo@master%pgi +claw')
 
     def test_devbuild_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
+        self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
+                self.Srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
             if machine == 'daint':
-                srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
+                self.Srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
         finally:
-            run('rm -rf cosmo')
+            self.Run('rm -rf cosmo')
 
     def test_devbuild_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
+        self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
+                self.Srun('spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
             if machine == 'daint':
-                srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
+                self.Srun('spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
         finally:
-            run('rm -rf cosmo')
+            self.Run('rm -rf cosmo')
 
     def test_install_old_version(self):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
-            srun('spack installcosmo cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+            self.Srun('spack installcosmo cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
                 )
 
 
-class CosmoDycoreTest(unittest.TestCase):
+class CosmoDycoreTest(TestCase):
     package_name = 'cosmo-dycore'
     depends_on = {'gridtools', 'serialbox', 'cuda'}
     machines = all_machines
 
 
-class CosmoEccodesDefinitionsTest(unittest.TestCase):
+class CosmoEccodesDefinitionsTest(TestCase):
     package_name = 'cosmo-eccodes-definitions'
     depends_on = {'eccodes'}
     machines = all_machines
 
 
-class CosmoGribApiTest(unittest.TestCase):
+class CosmoGribApiTest(TestCase):
     package_name = 'cosmo-grib-api'
     depends_on = {}
     machines = all_machines
 
 
-class CosmoGribApiDefinitionsTest(unittest.TestCase):
+class CosmoGribApiDefinitionsTest(TestCase):
     package_name = 'cosmo-grib-api-definitions'
     depends_on = {'cosmo-grib-api'}
     machines = all_machines
 
 
-class CudaTest(unittest.TestCase):
+class CudaTest(TestCase):
     package_name = 'cuda'
     depends_on = {}
     machines = all_machines
 
 
-class DawnTest(unittest.TestCase):
+class DawnTest(TestCase):
     package_name = 'dawn'
     depends_on = {}
     machines = all_machines
 
 
-class Dawn4PyTest(unittest.TestCase):
+class Dawn4PyTest(TestCase):
     package_name = 'dawn4py'
     depends_on = {}
     machines = all_machines
 
 
-class DuskTest(unittest.TestCase):
+class DuskTest(TestCase):
     package_name = 'dusk'
     depends_on = {'dawn4py'}
     machines = all_machines
 
 
-class DyiconBenchmarksTest(unittest.TestCase):
+class DyiconBenchmarksTest(TestCase):
     package_name = 'dyicon_benchmarks'
     depends_on = {'atlas_utilities', 'atlas', 'cuda'}
     machines = all_machines
 
 
-class EcbuildTest(unittest.TestCase):
+class EcbuildTest(TestCase):
     package_name = 'ecbuild'
     depends_on = {}
     machines = all_machines
 
 
-class EccodesTest(unittest.TestCase):
+class EccodesTest(TestCase):
     package_name = 'eccodes'
     depends_on = {}
     machines = all_machines
 
 
-class EckitTest(unittest.TestCase):
+class EckitTest(TestCase):
     package_name = 'eckit'
     depends_on = {'ecbuild'}
     machines = all_machines
 
 
-class GridToolsTest(unittest.TestCase):
+class GridToolsTest(TestCase):
     package_name = 'gridtools'
     depends_on = {'cuda'}
     machines = all_machines
 
 
-class IconTest(unittest.TestCase):
+class IconTest(TestCase):
     package_name = 'icon'
     depends_on = {'serialbox', 'eccodes', 'claw'}
     machines = {'daint'}
 
     def test_install_nwp_gpu_nvidia(self):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimick Buildbot for Tsa)
-        srun('spack install icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
+        self.Srun('spack install icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
             )
 
     def test_install_nwp_cpu_nvidia(self):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimick Buildbot for Tsa)
-        srun('spack install icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
+        self.Srun('spack install icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
             )
 
     # TODO: Reactivate once the test works!
     # def test_devbuild_cpu(self):
     #     # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-    #     run('git clone --recursive git@gitlab.dkrz.de:icon/icon-cscs.git')
-    #     run('mkdir -p icon-cscs/pgi_cpu')
-    #     run('touch a_fake_file.f90', cwd='icon-cscs/pgi_cpu')
+    #     self.Run('git clone --recursive git@gitlab.dkrz.de:icon/icon-cscs.git')
+    #     self.Run('mkdir -p icon-cscs/pgi_cpu')
+    #     self.Run('touch a_fake_file.f90', cwd='icon-cscs/pgi_cpu')
 
     #     try:
-    #         srun('spack dev-build -i -u build icon@dev-build%pgi config_dir=./.. icon_target=cpu', cwd='icon-cscs/pgi_cpu')
+    #         self.Srun('spack dev-build -i -u build icon@dev-build%pgi config_dir=./.. icon_target=cpu', cwd='icon-cscs/pgi_cpu')
     #     finally:
-    #         run('rm -rf icon-cscs')
+    #         self.Run('rm -rf icon-cscs')
 
     # TODO: Reactivate once the test works!
     # def test_devbuild_gpu(self):
     #     # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-    #     run('git clone --recursive git@gitlab.dkrz.de:icon/icon-cscs.git')
-    #     run('mkdir -p icon-cscs/pgi_gpu')
-    #     run('touch a_fake_file.f90', cwd='icon-cscs/pgi_gpu')
+    #     self.Run('git clone --recursive git@gitlab.dkrz.de:icon/icon-cscs.git')
+    #     self.Run('mkdir -p icon-cscs/pgi_gpu')
+    #     self.Run('touch a_fake_file.f90', cwd='icon-cscs/pgi_gpu')
 
     #     try:
-    #         srun('spack dev-build -i -u build icon@dev-build%pgi config_dir=./.. icon_target=gpu', cwd='icon-cscs/pgi_gpu')
+    #         self.Srun('spack dev-build -i -u build icon@dev-build%pgi config_dir=./.. icon_target=gpu', cwd='icon-cscs/pgi_gpu')
     #     finally:
-    #         run('rm -rf icon-cscs')
+    #         self.Run('rm -rf icon-cscs')
 
 
-class Int2lmTest(unittest.TestCase):
+class Int2lmTest(TestCase):
     package_name = 'int2lm'
     depends_on = {
         'cosmo-grib-api-definitions', 'cosmo-eccodes-definitions', 'libgrib1'
@@ -245,94 +247,94 @@ class Int2lmTest(unittest.TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            srun('spack install --test=root int2lm@c2sm-master%pgi')
+            self.Srun('spack install --test=root int2lm@c2sm-master%pgi')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            srun('spack install --test=root int2lm@org-master%pgi pollen=False')
+            self.Srun('spack install --test=root int2lm@org-master%pgi pollen=False')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        srun('spack install --test=root int2lm@c2sm-master%gcc')
+        self.Srun('spack install --test=root int2lm@c2sm-master%gcc')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            srun('spack install --test=root int2lm@c2sm-master%nvhpc')
+            self.Srun('spack install --test=root int2lm@c2sm-master%nvhpc')
 
 
-class IconDuskE2ETest(unittest.TestCase):
+class IconDuskE2ETest(TestCase):
     package_name = 'icondusk-e2e'
     depends_on = {'atlas_utilities', 'dawn4py', 'dusk', 'atlas', 'cuda'}
     machines = all_machines
 
 
-class IconToolsTest(unittest.TestCase):
+class IconToolsTest(TestCase):
     package_name = 'icontools'
     depends_on = {'eccodes', 'cosmo-grib-api'}
     machines = all_machines
 
     # C2SM supported version
     def test_install(self):
-        srun('spack install --test=root icontools@c2sm-master%gcc')
+        self.Srun('spack install --test=root icontools@c2sm-master%gcc')
 
 
-class LibGrib1Test(unittest.TestCase):
+class LibGrib1Test(TestCase):
     package_name = 'libgrib1'
     depends_on = {}
     machines = all_machines
 
 
-class LogTest(unittest.TestCase):
+class LogTest(TestCase):
     package_name = 'log'
     depends_on = {}
     machines = all_machines
 
 
-class MpichTest(unittest.TestCase):
+class MpichTest(TestCase):
     package_name = 'mpich'
     depends_on = {}
     machines = all_machines
 
 
-class OasisTest(unittest.TestCase):
+class OasisTest(TestCase):
     package_name = 'oasis'
     depends_on = {}
     machines = all_machines
 
 
-class OmniCompilerTest(unittest.TestCase):
+class OmniCompilerTest(TestCase):
     package_name = 'omnicompiler'
     depends_on = {}
     machines = all_machines
 
 
-class OmniXmodPoolTest(unittest.TestCase):
+class OmniXmodPoolTest(TestCase):
     package_name = 'omni-xmod-pool'
     depends_on = {}
     machines = all_machines
 
 
-class OpenMPITest(unittest.TestCase):
+class OpenMPITest(TestCase):
     package_name = 'openmpi'
     depends_on = {}
     machines = all_machines
 
 
-class SerialBoxTest(unittest.TestCase):
+class SerialBoxTest(TestCase):
     package_name = 'serialbox'
     depends_on = {}
     machines = all_machines
 
 
-class XcodeMLToolsTest(unittest.TestCase):
+class XcodeMLToolsTest(TestCase):
     package_name = 'xcodeml-tools'
     depends_on = {}
     machines = all_machines
 
 
-class ZLibNGTest(unittest.TestCase):
+class ZLibNGTest(TestCase):
     package_name = 'zlib_ng'
     depends_on = {}
     machines = all_machines
@@ -343,7 +345,7 @@ all_test_cases = {
     c
     for _, c in inspect.getmembers(
         sys.modules[__name__], lambda member: inspect.isclass(member) and
-        issubclass(member, unittest.TestCase))
+        issubclass(member, TestCase) and member != TestCase)
 }
 
 # Maps all packages in this repo to the set of packages they depend on. Must form a DAG.
@@ -535,7 +537,10 @@ if __name__ == '__main__':
         shell=True)
 
     if is_arbitrary_command:
-        run(joined_command)
+        setup = ''
+        if joined_command.startswith('spack'):
+            setup = f'source spack/share/spack/setup-env.sh &&'
+        subprocess.run(f'{setup} {joined_command} >> {machine}.log', check=True, shell=True)
         sys.exit()
     else:
         # collect and run tests from all packages selected

--- a/test_spack.py
+++ b/test_spack.py
@@ -79,11 +79,11 @@ class CosmoTest(TestCase):
     def test_install_master_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Run(
+            self.Srun(
                 'spack installcosmo cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
             )
         if machine == 'daint':
-            self.Run(
+            self.Srun(
                 'spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
             )
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -497,18 +497,25 @@ if __name__ == '__main__':
         exclusive = True
         commands.remove('--exclusive')
 
+    machine_count = 0
     if '--daint' in commands:
         machine = 'daint'
         spack_machine = machine
-        commands.remove('--daint')
+        commands = [x for x in commands if x != '--daint']
+        machine_count += 1
     if '--dom' in commands:
         machine = 'daint'
         spack_machine = 'dom'
-        commands.remove('--dom')
+        commands = [x for x in commands if x != '--dom']
+        machine_count += 1
     if '--tsa' in commands:
         machine = 'tsa'
         spack_machine = machine
-        commands.remove('--tsa')
+        commands = [x for x in commands if x != '--tsa']
+        machine_count += 1
+
+    if machine_count != 1:
+        sys.exit()
 
     known_commands = dependencies.keys() | expansions.keys()
 


### PR DESCRIPTION
This PR addresses https://github.com/C2SM/spack-c2sm/issues/420.
Developer's to-do:
- [X] Remove the `srun` launching of `test_spack.py`
- [X] Add `srun` to individual tests, or not.
- [x] Stream the output of each test into an individual log file and gather them as artifacts.
- [X] Name them `<machine>_<package>_<test_name>.log`
- [x] Print the output of the testing framework into the jenkins console, not the output of the tests them-self.
- [x] Add an option to run tests on only one machine.
- [x] Run the tests in parallel.

**Technical description of changes:**
Adds `class TestCase(unittest.TestCase)` in between test-classes and the unittest framework, to provide functions `Run` and `Srun` so each test-calss' package name and method name can be accessed. (Because the method name goes into the log file name) This replaces the free function `run`.
Adds `class CustomTestSuite(unittest.TestSuite)` which is able to run tests in parallel. Shamelessly copied from StackOverflow.
Adds a variable `machine_count`, which counts how many machines are passed as arguments. If multiple occur, execution is halted, because the user specified an explicit machine. Specifying multiple machines is not supported at the moment.
Adds `--tsa` and `--daint` to documentation.