### PR TITLE
Bugfix: tests didn't run with cppdycore

### DIFF
--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -65,7 +65,8 @@ def custom_devbuild(source_path, spec, args):
     elif args.things_to_test == 'all':
         args.things_to_test = True
 
-    # Bugfix: somehow args are changed outside of function when changed here
+    # Bugfix: somehow args are changed outside of function when changed inside here
+    # Therefore, at second call of this function things_to_test is a list
     elif isinstance(args.things_to_test, list):
         if args.things_to_test[0] != 'cosmo':
             tty.die("spack dev-build requires a package spec argument.")

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -69,7 +69,7 @@ def custom_devbuild(source_path, spec, args):
     # Therefore, at second call of this function things_to_test is a list
     elif isinstance(args.things_to_test, list):
         if args.things_to_test[0] != 'cosmo':
-            tty.die("unknown entry in devbuildcosmo for argument '--test' " )
+            tty.die("unknown entry in devbuildcosmo for argument '--test' ")
 
     else:
         args.things_to_test = False

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -65,6 +65,11 @@ def custom_devbuild(source_path, spec, args):
     elif args.things_to_test == 'all':
         args.things_to_test = True
 
+    # Bugfix: somehow args are changed outside of function when changed here
+    elif isinstance(args.things_to_test, list):
+        if args.things_to_test[0] != 'cosmo':
+            tty.die("spack dev-build requires a package spec argument.")
+
     else:
         args.things_to_test = False
 

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -69,7 +69,7 @@ def custom_devbuild(source_path, spec, args):
     # Therefore, at second call of this function things_to_test is a list
     elif isinstance(args.things_to_test, list):
         if args.things_to_test[0] != 'cosmo':
-            tty.die("spack dev-build requires a package spec argument.")
+            tty.die("unknown entry in devbuildcosmo for argument '--test' " )
 
     else:
         args.things_to_test = False


### PR DESCRIPTION
For some reason the function custom_devbuild changes args also outside the function. Thus, if the function is called twice, args.things_to_test was no longer one of the options and was therefore set to false. The function was called twice when running spack devbuildcosmo with cppdycore (+cppdycore), which is why the testsuite wasn't run.