### PR TITLE
Adds aec support to cosmo

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -245,6 +245,12 @@ class Cosmo(MakefilePackage):
         else:
             env.set('GRIBAPII', '')
 
+        # libaec
+        if 'libaec' in self.spec:
+            env.set('AECL', '-L' + self.spec['libaec'].prefix + '/lib64 -laec')
+            env.set('AECI', '-I' + self.spec['libaec'].prefix + '/include')
+
+
         # Netcdf library
         if self.spec.variants['slave'].value == 'daint':
             env.set('NETCDFL', '-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -250,7 +250,6 @@ class Cosmo(MakefilePackage):
             env.set('AECL', '-L' + self.spec['libaec'].prefix + '/lib64 -laec')
             env.set('AECI', '-I' + self.spec['libaec'].prefix + '/include')
 
-
         # Netcdf library
         if self.spec.variants['slave'].value == 'daint':
             env.set('NETCDFL', '-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf')


### PR DESCRIPTION
Adds env variables if 'libaec' is in the specs.
It would be nicer to add this to eccodes but that doesn't work. So this is the best way I was able to make it work.