### PR TITLE
Icon transit

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -54,7 +54,7 @@ class Icon(Package):
                when='+eccodes',
                type=('build', 'link', 'run'))
     depends_on('claw@2.0.2', when='+claw', type=('build', 'link', 'run'))
-    depends_on('netcdf-fortran', when='~unpatched-wrapper')
+    depends_on('netcdf-fortran', when='+proper-netcdf-dep')
 
     variant('icon_target',
             default='gpu',
@@ -102,7 +102,7 @@ class Icon(Package):
     variant('silent-rules',
             default=True,
             description='Build with Make silent rules ON')
-    variant('unpatched-wrapper', default=False, description='Have proper dependency on netcdf-fortran (temporary)')
+    variant('proper-netcdf-dep', default=False, description='Have proper dependency on netcdf-fortran (temporary)')
 
     conflicts('icon_target=cpu', when='+claw')
     conflicts('icon_target=gpu', when='%intel')

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -54,7 +54,7 @@ class Icon(Package):
                when='+eccodes',
                type=('build', 'link', 'run'))
     depends_on('claw@2.0.2', when='+claw', type=('build', 'link', 'run'))
-    depends_on('netcdf-fortran')
+    depends_on('netcdf-fortran', when='~unpatched-wrapper')
 
     variant('icon_target',
             default='gpu',
@@ -102,6 +102,7 @@ class Icon(Package):
     variant('silent-rules',
             default=True,
             description='Build with Make silent rules ON')
+    variant('unpatched-wrapper', default=False, description='Have proper dependency on netcdf-fortran (temporary)')
 
     conflicts('icon_target=cpu', when='+claw')
     conflicts('icon_target=gpu', when='%intel')


### PR DESCRIPTION
Introduce `+proper-netcdf-dep` so that:
- people with unpatched ICON wrappers can still build without changing their ICON source - no action required
- people with the latest wrapper can build aswell but have to add the `+proper-netcdf-dep` variant to the spack call.

How I think merging this will work:
1. merge this change into spack-c2sm:master
2. wait until spack instance is updated
3. verify buildbot passes all tests with ICON MR (https://gitlab.dkrz.de/icon/icon-nwp/-/merge_requests/426)
4. merge on ICON-side
5. after X amount of time: remove `proper-netcdf-dep` variant to enforce proper netcdf dependency