### PR TITLE
[Cosmo] Add cosmo-ghg version

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -11,6 +11,7 @@ class CosmoDycore(CMakePackage):
     git = "git@github.com:COSMO-ORG/cosmo.git"
     apngit = "git@github.com:MeteoSwiss-APN/cosmo.git"
     c2smgit = "git@github.com:C2SM-RCM/cosmo.git"
+    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
 
     maintainers = ['elsagermann']
 
@@ -25,10 +26,12 @@ class CosmoDycore(CMakePackage):
     version('c2sm-features',
             git='git@github.com:C2SM-RCM/cosmo.git',
             branch='c2sm-features')
+    version('empa-ghg', git=empagit, branch='c2sm')
 
     set_versions(version, apngit, 'apn', regex_filter='.*mch.*')
     set_versions(version, c2smgit, 'c2sm')
     set_versions(version, git, 'org')
+    set_versions(version, empagit, 'empa')
 
     #deprecated
     version('master', branch='master')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -419,7 +419,7 @@ class Cosmo(MakefilePackage):
 
             makefile = FileFilter('Makefile')
             makefile.filter('/Options.*', '/' + OptionsFileName)
-            if self.spec.version == 'empa-ghg':
+            if self.spec.version == Version('empa-ghg'):
                 if '~serialize' in spec:
                     makefile.filter(
                         'TARGET     :=.*', 'TARGET     := {0}'.format(
@@ -459,7 +459,7 @@ class Cosmo(MakefilePackage):
 
         with working_dir(self.build_directory):
             mkdir(prefix.bin)
-            if self.spec.version == 'empa-ghg':
+            if self.spec.version == Version('empa-ghg'):
                 if '+serialize' in spec:
                     install('cosmo-ghg_serialize', prefix.bin)
                 else:

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -419,13 +419,22 @@ class Cosmo(MakefilePackage):
 
             makefile = FileFilter('Makefile')
             makefile.filter('/Options.*', '/' + OptionsFileName)
-            if '~serialize' in spec:
-                makefile.filter(
-                    'TARGET     :=.*', 'TARGET     := {0}'.format(
-                        'cosmo_' + spec.variants['cosmo_target'].value))
+            if self.spec.version == 'empa-ghg':
+                if '~serialize' in spec:
+                    makefile.filter(
+                        'TARGET     :=.*', 'TARGET     := {0}'.format(
+                            'cosmo-ghg_' + spec.variants['cosmo_target'].value))
+                else:
+                    makefile.filter('TARGET     :=.*',
+                                    'TARGET     := {0}'.format('cosmo-ghg'))
             else:
-                makefile.filter('TARGET     :=.*',
-                                'TARGET     := {0}'.format('cosmo'))
+                if '~serialize' in spec:
+                    makefile.filter(
+                        'TARGET     :=.*', 'TARGET     := {0}'.format(
+                            'cosmo_' + spec.variants['cosmo_target'].value))
+                else:
+                    makefile.filter('TARGET     :=.*',
+                                    'TARGET     := {0}'.format('cosmo'))
 
             if 'cosmo_target=gpu' in self.spec:
                 cuda_version = self.spec['cuda'].version
@@ -450,13 +459,22 @@ class Cosmo(MakefilePackage):
 
         with working_dir(self.build_directory):
             mkdir(prefix.bin)
-            if '+serialize' in spec:
-                install('cosmo_serialize', prefix.bin)
+            if self.spec.version == 'empa-ghg':
+                if '+serialize' in spec:
+                    install('cosmo-ghg_serialize', prefix.bin)
+                else:
+                    install('cosmo-ghg_' + self.spec.variants['cosmo_target'].value,
+                            prefix.bin)
+                    install('cosmo-ghg_' + self.spec.variants['cosmo_target'].value,
+                            'test/testsuite')
             else:
-                install('cosmo_' + self.spec.variants['cosmo_target'].value,
-                        prefix.bin)
-                install('cosmo_' + self.spec.variants['cosmo_target'].value,
-                        'test/testsuite')
+                if '+serialize' in spec:
+                    install('cosmo_serialize', prefix.bin)
+                else:
+                    install('cosmo_' + self.spec.variants['cosmo_target'].value,
+                            prefix.bin)
+                    install('cosmo_' + self.spec.variants['cosmo_target'].value,
+                            'test/testsuite')
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -16,6 +16,7 @@ class Cosmo(MakefilePackage):
     git = 'git@github.com:COSMO-ORG/cosmo.git'
     apngit = 'git@github.com:MeteoSwiss-APN/cosmo.git'
     c2smgit = 'git@github.com:C2SM-RCM/cosmo.git'
+    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
     maintainers = ['elsagermann']
 
     version('org-master', branch='master', get_full_repo=True)
@@ -26,6 +27,7 @@ class Cosmo(MakefilePackage):
             git=c2smgit,
             branch='c2sm-features',
             get_full_repo=True)
+    version('empa-ghg', git=empagit, branch='c2sm', get_full_repo=True)
 
     #deprecated
     version('master', branch='master', get_full_repo=True)
@@ -36,6 +38,7 @@ class Cosmo(MakefilePackage):
 
     set_versions(version, apngit, 'apn', regex_filter='.*mch.*')
     set_versions(version, c2smgit, 'c2sm')
+    set_versions(version, empagit, 'empa')
 
     depends_on('netcdf-fortran', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))


### PR DESCRIPTION
Empa uses a modified version of COSMO (with greenhouse-gas tracers): https://github.com/C2SM-RCM/cosmo-ghg

This should be build with spack now. Additionally, I tried to change the name of the executable to `cosmo-ghg` to avoid confusion with standard `cosmo`. However, it doesn't work at the moment and there is some duplication of code.