### PR TITLE
[Serialbox] Import "official" package from Sergey

### DIFF
--- a/packages/claw/package.py
+++ b/packages/claw/package.py
@@ -42,7 +42,7 @@ class Claw(CMakePackage):
             commit='16b165a443b11b025a77cad830b1280b8c9bcf01',
             submodules=True)
 
-    depends_on('cmake@3.12:%gcc', type='build')
+    depends_on('cmake@3.12:', type='build')
     depends_on('java@8:', when="@2.0:")
     depends_on('java@7:', when="@1.1.0:1.2.3")
     depends_on('ant@1.9:', type='build')

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -115,7 +115,7 @@ class CosmoDycore(CMakePackage):
     depends_on('mpicuda', type=('build', 'link', 'run'), when='+cuda')
     depends_on('mpi', type=('build', 'link', 'run'), when='~cuda')
     depends_on('slurm%gcc', type='run')
-    depends_on('cmake@3.12:%gcc')
+    depends_on('cmake@3.12:')
     depends_on('cuda%gcc', when='+cuda', type=('build', 'link', 'run'))
 
     conflicts('+production', when='build_type=Debug')

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -11,6 +11,7 @@ class CosmoDycore(CMakePackage):
     git = "git@github.com:COSMO-ORG/cosmo.git"
     apngit = "git@github.com:MeteoSwiss-APN/cosmo.git"
     c2smgit = "git@github.com:C2SM-RCM/cosmo.git"
+    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
 
     maintainers = ['elsagermann']
 
@@ -25,10 +26,12 @@ class CosmoDycore(CMakePackage):
     version('c2sm-features',
             git='git@github.com:C2SM-RCM/cosmo.git',
             branch='c2sm-features')
+    version('empa-ghg', git=empagit, branch='c2sm')
 
     set_versions(version, apngit, 'apn', regex_filter='.*mch.*')
     set_versions(version, c2smgit, 'c2sm')
     set_versions(version, git, 'org')
+    set_versions(version, empagit, 'empa')
 
     #deprecated
     version('master', branch='master')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -63,7 +63,7 @@ class Cosmo(MakefilePackage):
     depends_on('omni-xmod-pool', when='+claw', type='build')
     depends_on('claw%gcc', when='+claw', type='build')
     depends_on('boost%gcc', when='cosmo_target=gpu ~cppdycore', type='build')
-    depends_on('cmake%gcc', type='build')
+    depends_on('cmake', type='build')
     depends_on('zlib_ng +compat', when='+zlib_ng', type=('link', 'run'))
     depends_on('oasis', when='+oasis', type=('build', 'link', 'run'))
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -16,6 +16,7 @@ class Cosmo(MakefilePackage):
     git = 'git@github.com:COSMO-ORG/cosmo.git'
     apngit = 'git@github.com:MeteoSwiss-APN/cosmo.git'
     c2smgit = 'git@github.com:C2SM-RCM/cosmo.git'
+    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
     maintainers = ['elsagermann']
 
     version('org-master', branch='master', get_full_repo=True)
@@ -26,6 +27,7 @@ class Cosmo(MakefilePackage):
             git=c2smgit,
             branch='c2sm-features',
             get_full_repo=True)
+    version('empa-ghg', git=empagit, branch='c2sm', get_full_repo=True)
 
     #deprecated
     version('master', branch='master', get_full_repo=True)
@@ -36,6 +38,7 @@ class Cosmo(MakefilePackage):
 
     set_versions(version, apngit, 'apn', regex_filter='.*mch.*')
     set_versions(version, c2smgit, 'c2sm')
+    set_versions(version, empagit, 'empa')
 
     depends_on('netcdf-fortran', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))
@@ -416,13 +419,23 @@ class Cosmo(MakefilePackage):
 
             makefile = FileFilter('Makefile')
             makefile.filter('/Options.*', '/' + OptionsFileName)
-            if '~serialize' in spec:
-                makefile.filter(
-                    'TARGET     :=.*', 'TARGET     := {0}'.format(
-                        'cosmo_' + spec.variants['cosmo_target'].value))
+            if self.spec.version == Version('empa-ghg'):
+                if '~serialize' in spec:
+                    makefile.filter(
+                        'TARGET     :=.*', 'TARGET     := {0}'.format(
+                            'cosmo-ghg_' +
+                            spec.variants['cosmo_target'].value))
+                else:
+                    makefile.filter('TARGET     :=.*',
+                                    'TARGET     := {0}'.format('cosmo-ghg'))
             else:
-                makefile.filter('TARGET     :=.*',
-                                'TARGET     := {0}'.format('cosmo'))
+                if '~serialize' in spec:
+                    makefile.filter(
+                        'TARGET     :=.*', 'TARGET     := {0}'.format(
+                            'cosmo_' + spec.variants['cosmo_target'].value))
+                else:
+                    makefile.filter('TARGET     :=.*',
+                                    'TARGET     := {0}'.format('cosmo'))
 
             if 'cosmo_target=gpu' in self.spec:
                 cuda_version = self.spec['cuda'].version
@@ -447,12 +460,26 @@ class Cosmo(MakefilePackage):
 
         with working_dir(self.build_directory):
             mkdir(prefix.bin)
-            if '+serialize' in spec:
-                install('cosmo_serialize', prefix.bin)
+            if self.spec.version == Version('empa-ghg'):
+                if '+serialize' in spec:
+                    install('cosmo-ghg_serialize', prefix.bin)
+                else:
+                    install(
+                        'cosmo-ghg_' +
+                        self.spec.variants['cosmo_target'].value, prefix.bin)
+                    install(
+                        'cosmo-ghg_' +
+                        self.spec.variants['cosmo_target'].value,
+                        'test/testsuite')
             else:
-                install('cosmo_' + self.spec.variants['cosmo_target'].value,
+                if '+serialize' in spec:
+                    install('cosmo_serialize', prefix.bin)
+                else:
+                    install(
+                        'cosmo_' + self.spec.variants['cosmo_target'].value,
                         prefix.bin)
-                install('cosmo_' + self.spec.variants['cosmo_target'].value,
+                    install(
+                        'cosmo_' + self.spec.variants['cosmo_target'].value,
                         'test/testsuite')
 
     @run_after('install')

--- a/packages/eccodes/package.py
+++ b/packages/eccodes/package.py
@@ -72,7 +72,7 @@ class Eccodes(CMakePackage):
     # tests are enabled but the testing scripts don't use it.
     # depends_on('valgrind', type='test', when='+test')
 
-    depends_on('cmake@3.14.5:%gcc')
+    depends_on('cmake@3.14.5:')
     depends_on('netcdf-c', when='+netcdf')
     depends_on('openjpeg@1.5.0:1.5.999,2.1.0:2.1.999', when='jp2k=openjpeg')
     depends_on('jasper%gcc', when='jp2k=jasper', type='build')

--- a/packages/gridtools/package.py
+++ b/packages/gridtools/package.py
@@ -52,7 +52,7 @@ class Gridtools(CMakePackage):
     variant('cuda', default=True, description='Build with cuda or target gpu')
 
     depends_on('ncurses')
-    depends_on('cmake@3.14.5:%gcc')
+    depends_on('cmake@3.14.5:')
     depends_on('boost@1.67.0:')
     depends_on('mpi', type=('build', 'link', 'run'), when='~cuda')
     depends_on('mpicuda', type=('build', 'link', 'run'), when='+cuda')

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -39,7 +39,7 @@ class Icon(Package):
             git='git@github.com:C2SM/icon-exclaim.git',
             submodules=True)
 
-    depends_on('cmake%gcc')
+    depends_on('cmake')
     depends_on('libxml2@2.9.8:%gcc', type=('build', 'link', 'run'))
     depends_on('serialbox@2.6.0 ~python ~sdb ~shared',
                when='serialize_mode=create',

--- a/packages/serialbox/nag/examples.patch
+++ b/packages/serialbox/nag/examples.patch
@@ -1,0 +1,27 @@
+# This patch is applicable starting version 2.3.1
+--- a/examples/fortran/simple/m_ser.F90
++++ b/examples/fortran/simple/m_ser.F90
+@@ -38 +38 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
+@@ -59 +59 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
+@@ -91,2 +91,2 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
+-    REAL(KIND=8) :: rprecision
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)) :: rprecision
+@@ -97 +97 @@ USE utils_ppser, ONLY:  &
+-          prefix_ref='SerialboxTest',rprecision=rprecision,rperturb=1.0e-5_8)
++          prefix_ref='SerialboxTest',rprecision=rprecision,rperturb=REAL(1.0e-5,SELECTED_REAL_KIND(15)))
+--- a/examples/fortran/simple/main_consumer.F90
++++ b/examples/fortran/simple/main_consumer.F90
+@@ -14 +14 @@ PROGRAM main_consumer
+-  REAL(KIND=8), DIMENSION(5,5,5) :: a
++  REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(5,5,5) :: a
+--- a/examples/fortran/simple/main_producer.F90
++++ b/examples/fortran/simple/main_producer.F90
+@@ -14 +14 @@ PROGRAM main_producer
+-  REAL(KIND=8), DIMENSION(5,5,5) :: a
++  REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(5,5,5) :: a

--- a/packages/serialbox/nag/ftg.patch
+++ b/packages/serialbox/nag/ftg.patch
@@ -1,0 +1,31 @@
+# This patch is applicable starting version 2.3.1
+--- a/src/serialbox-fortran/m_ser_ftg.f90
++++ b/src/serialbox-fortran/m_ser_ftg.f90
+@@ -822,5 +822,5 @@ SUBROUTINE ftg_write_logical_1d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -853,5 +853,5 @@ SUBROUTINE ftg_write_logical_2d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -886,5 +886,5 @@ SUBROUTINE ftg_write_logical_3d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -919,5 +919,5 @@ SUBROUTINE ftg_write_logical_4d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 

--- a/packages/serialbox/nag/interface.patch
+++ b/packages/serialbox/nag/interface.patch
@@ -1,0 +1,9 @@
+# This patch is applicable starting version 2.0.1
+--- a/src/serialbox-fortran/utils_ppser.f90
++++ b/src/serialbox-fortran/utils_ppser.f90
+@@ -33 +33 @@ MODULE utils_ppser
+-USE iso_fortran_env
++USE f90_unix_proc; USE iso_fortran_env
+@@ -66 +66 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
+-  REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
++  REAL(KIND=SELECTED_REAL_KIND(15)), OPTIONAL, INTENT(IN)     :: rprecision, rperturb

--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -45,7 +45,7 @@ class Serialbox(CMakePackage):
     # with https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
     depends_on('cmake@3.19:', when='%pgi', type='build')
 
-    depends_on('boost@1.54:', type='build')
+    depends_on('boost@1.67.0%gcc', type='build')
     depends_on('boost+filesystem+system',
                when='~std-filesystem', type=('build', 'link'))
 

--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -1,145 +1,206 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install serialbox
-#
-# You can edit this file again by typing:
-#
-#     spack edit serialbox
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 
-from spack import *
+from spack.package import *
 
 
 class Serialbox(CMakePackage):
-    """Serialbox is part of the GridTools Framework. Serialbox is a serialization library and tools for C/C++, Python3 and Fortran."""
+    """Serialbox is a serialization library and tools for C/C++, Python3 and
+    Fortran. Serialbox is used in several projects for building validation
+    frameworks against reference runs."""
+
     homepage = "https://github.com/GridTools/serialbox"
-    url = "https://github.com/GridTools/serialbox/archive/v2.6.0.tar.gz"
-    git = "https://github.com/GridTools/serialbox.git"
+    url = "https://github.com/GridTools/serialbox/archive/v2.6.1.tar.gz"
 
-    maintainers = ['elsagermann']
+    maintainers = ['skosukhin']
 
-    version('master', branch='master')
-    version('2.6.0', commit='eed195c47ab771c1682121ccbc89d2a556cdcb86')
-    version('2.5.4', commit='26de94919c1b405b5900df5825791be4fa703ec0')
-    version('2.4.3', commit='f15bd29db2e75d4e775bd133400bab33df55856b')
+    version('2.6.1', sha256='b795ce576e8c4fd137e48e502b07b136079c595c82c660cfa2e284b0ef873342')
+    version('2.6.0', sha256='9199f8637afbd7f2b3c5ba932d1c63e9e14d553a0cafe6c29107df0e04ee9fae')
+    version('2.5.4', sha256='f4aee8ef284f58e6847968fe4620e222ac7019d805bbbb26c199e4b6a5094fee')
+    version('2.5.3', sha256='696499b3f43978238c3bcc8f9de50bce2630c07971c47c9e03af0324652b2d5d')
 
-    depends_on('boost@1.67.0%gcc')
+    variant('c', default=True, description='enable C interface')
+    variant('python', default=False, description='enable Python interface')
+    variant('fortran', default=False, description='enable Fortran interface')
+    variant('ftg', default=False,
+            description='enable FortranTestGenerator frontend')
+    variant('sdb', default=False, description='enable stencil debugger')
+    variant('shared', default=True, description='build shared libraries')
+    variant('examples', default=False, description='build the examples')
+    variant('logging', default=True,
+            description='enable the logging infrastructure')
+    variant('async-api', default=True,
+            description='enable the asynchronous API')
+    variant('netcdf', default=False,
+            description='build the NetCDF archive backend')
+    variant('std-filesystem', default=True,
+            description='use std::experimental::filesystem (no dependency on '
+                        'compiled boost libs)')
+
+    depends_on('cmake@3.12:', type='build')
+    # We might be provided with an external vanilla cmake, and we need one with
+    # with https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
+    depends_on('cmake@3.19:', when='%pgi', type='build')
+
+    depends_on('boost@1.54:', type='build')
+    depends_on('boost+filesystem+system',
+               when='~std-filesystem', type=('build', 'link'))
+
     depends_on('netcdf-c', when='+netcdf')
-    depends_on('netcdf-cxx4', when='+netcdf')
 
-    variant('build_type',
-            default='Release',
-            description='Build type',
-            values=('Debug', 'Release', 'DebugRelease'))
-    variant(
-        'fortran',
-        default=True,
-        description='Build the C interface of Serialbox (libSerialboxFortran)')
-    variant('shared',
-            default=True,
-            description='Build shared libraries of Serialbox')
-    variant('exp_filesystem',
-            default=True,
-            description='Build with experimental filesystem')
-    variant('ftg', default=True, description='Build with ftg')
-    variant('no_pckg_registery',
-            default=True,
-            description='Build with Cmake export no package registey')
-    variant('testing_gridtools',
-            default=False,
-            description='Build with testing gridtools')
-    variant('testing_fortran',
-            default=False,
-            description='Build with testing fortran')
-    variant('testing_stella',
-            default=False,
-            description='Build with testing stella')
-    variant('netcdf', default=False, description='Build using netcdf')
-    variant('boost_sys_paths',
-            default=True,
-            description='Build boost with no system paths')
-    variant('boost_cmake',
-            default=True,
-            description='Build boost without using CMake')
-    variant('python',
-            default=True,
-            description='Build Python3 interface of SerialboxBuild')
-    variant('sdb', default=True, description='Build stencil debugger sdb')
-    variant('examples', default=True, description='Build examples')
+    # The preprocessor can be run with Python 2:
+    depends_on('python', type='run')
+    # The Python interface is compatible only with Python 3:
+    depends_on('python@3.4:', when='+python', type=('build', 'run'))
+    depends_on('py-numpy', when='+python', type=('build', 'run'))
+
+    # pp_ser fails to process source files containing Unicode character with
+    # Python 3 (https://github.com/GridTools/serialbox/pull/249):
+    patch('ppser_py3.patch', when='@2.2.1:')
+
+    # NAG patches:
+    patch('nag/interface.patch', when='@2.0.1:%nag+fortran')
+    patch('nag/examples.patch', when='@2.3.1:%nag+fortran+examples')
+    patch('nag/ftg.patch', when='@2.3.1:%nag+ftg')
+
+    conflicts('+ftg', when='~fortran',
+              msg='the FortranTestGenerator frontend requires the Fortran '
+                  'interface')
+    conflicts('+ftg', when='@:2.2.999',
+              msg='the FortranTestGenerator frontend is supported only '
+                  'starting version 2.3.0')
+    conflicts('+sdb', when='~python',
+              msg='the stencil debugger requires the Python interface')
+    conflicts('+fortran', when='~c',
+              msg='the Fortran interface requires the C interface')
+    conflicts('+python', when='~c',
+              msg='the Python interface requires the C interface')
+    conflicts('+python', when='~shared',
+              msg='the Python interface requires the shared libraries')
+
+    def patch(self):
+        # The following is implemented as a method to avoid having two sets of
+        # almost identical patch files: one with the CR symbols (for versions
+        # 2.5.x) and one without them (for versions 2.6.x).
+
+        # Remove hard-coded -march=native
+        # (see https://github.com/GridTools/serialbox/pull/233):
+        if self.spec.satisfies('@2.0.1:2.6.0'):
+            filter_file(
+                r'^(\s*set\(CMAKE_CXX_FLAGS.*-march=native)',
+                r'#\1', 'CMakeLists.txt')
+
+        # Do not fallback to boost::filesystem:
+        if '+std-filesystem' in self.spec:
+            filter_file(
+                r'(message\()'
+                r'STATUS( "std::experimental::filesystem not found).*("\))',
+                r'\1FATAL_ERROR\2\3', 'CMakeLists.txt')
+
+    @property
+    def libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+
+        shared = '+shared' in self.spec
+
+        query2libraries = {
+            tuple(): ['libSerialboxCore'],
+            ('c', 'fortran'): [
+                'libSerialboxFortran',
+                'libSerialboxC',
+                'libSerialboxCore',
+            ],
+            ('c',): [
+                'libSerialboxC',
+                'libSerialboxCore',
+            ],
+            ('fortran',): [
+                'libSerialboxFortran',
+                'libSerialboxC',
+                'libSerialboxCore'
+            ]
+        }
+
+        key = tuple(sorted(query_parameters))
+        libraries = query2libraries[key]
+
+        if self.spec.satisfies('@2.5.0:2.5'):
+            libraries = [
+                '{0}{1}'.format(name, 'Shared' if shared else 'Static')
+                for name in libraries]
+
+        libs = find_libraries(
+            libraries, root=self.prefix, shared=shared, recursive=True)
+
+        if libs:
+            return libs
+
+        msg = 'Unable to recursively locate {0} libraries in {1}'
+        raise spack.error.NoLibrariesError(
+            msg.format(self.spec.name, self.spec.prefix))
+
+    def flag_handler(self, name, flags):
+        cmake_flags = []
+
+        if name == 'cxxflags':
+            # Intel (at least up to version 19.0.1, version 19.0.4 works) and
+            # PGI (at least up to version 19.9, version 20.1.0 works) compilers
+            # have problems with C++11 name mangling. An attempt to link to
+            # libSerialboxCore leads to:
+            # undefined reference to
+            #     `std::experimental::filesystem::v1::__cxx11::path::
+            #         _M_find_extension[abi:cxx11]() const'
+            if any(self.spec.satisfies('{0}+std-filesystem'.format(x))
+                   for x in ['%intel@:19.0.1', '%pgi@:19.9']):
+                cmake_flags.append('-D_GLIBCXX_USE_CXX11_ABI=0')
+
+        if self.compiler.name == 'nvhpc' and name in ['cflags', 'cxxflags']:
+                cmake_flags.append('-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1')
+
+        return flags, None, (cmake_flags or None)
+
+    def setup_run_environment(self, env):
+        # Allow for running the preprocessor directly:
+        env.prepend_path('PATH', self.prefix.python.pp_ser)
+        # Allow for running the preprocessor as a Python module, as well as
+        # enable the Python interface in a non-standard directory:
+        env.prepend_path('PYTHONPATH', self.prefix.python)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        # Simplify the location of the preprocessor by dependent packages:
+        self.spec.pp_ser = join_path(self.prefix.python.pp_ser, 'pp_ser.py')
 
     def cmake_args(self):
-        args = []
+        args = [
+            '-DBOOST_ROOT:PATH=%s' % self.spec['boost'].prefix,
+            # https://cmake.org/cmake/help/v3.15/module/FindBoost.html#boost-cmake
+            self.define('Boost_NO_BOOST_CMAKE', True),
+            self.define_from_variant('SERIALBOX_ENABLE_C', 'c'),
+            self.define_from_variant('SERIALBOX_ENABLE_PYTHON', 'python'),
+            self.define_from_variant('SERIALBOX_ENABLE_FORTRAN', 'fortran'),
+            self.define_from_variant('SERIALBOX_ENABLE_FTG', 'ftg'),
+            self.define_from_variant('SERIALBOX_ENABLE_SDB', 'sdb'),
+            self.define_from_variant('SERIALBOX_BUILD_SHARED', 'shared'),
+            self.define_from_variant('SERIALBOX_EXAMPLES', 'examples'),
+            self.define_from_variant('SERIALBOX_LOGGING', 'logging'),
+            self.define_from_variant('SERIALBOX_ASYNC_API', 'async-api'),
+            # CMake scripts of Serialbox (at least up to version 2.6.0) are
+            # broken and do not instruct the compiler to link to the OpenSSL
+            # libraries:
+            self.define('SERIALBOX_USE_OPENSSL', False),
+            self.define_from_variant('SERIALBOX_ENABLE_EXPERIMENTAL_FILESYSTEM',
+                                     'std-filesystem'),
+            self.define_from_variant('SERIALBOX_USE_NETCDF', 'netcdf'),
+            self.define('SERIALBOX_TESTING', self.run_tests),
+        ]
 
-        args.append('-DCMAKE_C_COMPILER=gcc')
-        args.append('-DCMAKE_CXX_COMPILER=g++')
-        args.append('-DCMAKE_BUILD_TYPE={0}'.format(
-            self.spec.variants['build_type'].value))
-        args.append('-DBOOST_ROOT={0}'.format(self.spec['boost'].prefix))
-
-        if '+boost_sys_paths' in self.spec:
-            args.append('-DBoost_NO_SYSTEM_PATHS=ON')
-        else:
-            args.append('-DBoost_NO_SYSTEM_PATHS=OFF')
-        if '+boost_cmake' in self.spec:
-            args.append('-DBoost_NO_BOOST_CMAKE=ON')
-        else:
-            args.append('-DBoost_NO_BOOST_CMAKE=OFF')
         if '+netcdf' in self.spec:
-            args.append('-DSERIALBOX_USE_NETCDF=ON')
-        else:
-            args.append('-DSERIALBOX_USE_NETCDF=OFF')
-        if '+testing_gridtools' in self.spec:
-            args.append('-DSERIALBOX_TESTING_GRIDTOOLS=ON')
-        else:
-            args.append('-DSERIALBOX_TESTING_GRIDTOOLS=OFF')
-        if '+testing_stella' in self.spec:
-            args.append('-DSERIALBOX_TESTING_STELLA=ON')
-        else:
-            args.append('-DSERIALBOX_TESTING_STELLA=OFF')
-        if '+testing_stella' in self.spec:
-            args.append('-DSERIALBOX_TESTING_FORTRAN=ON')
-        else:
-            args.append('-DSERIALBOX_TESTING_FORTRAN=OFF')
-        if '+no_pckg_registery' in self.spec:
-            args.append('-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON')
-        else:
-            args.append('-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=OFF')
-        if '+ftg' in self.spec:
-            args.append('-DSERIALBOX_ENABLE_FTG=ON')
-        else:
-            args.append('-DSERIALBOX_ENABLE_FTG=OFF')
-        if '+exp_filesystem' in self.spec:
-            args.append('-DSERIALBOX_ENABLE_EXPERIMENTAL_FILESYSTEM=ON')
-        else:
-            args.append('-DSERIALBOX_ENABLE_EXPERIMENTAL_FILESYSTEM=OFF')
-        if '+fortran' in self.spec:
-            args.append('-DSERIALBOX_ENABLE_FORTRAN=ON')
-        else:
-            args.append('-DSERIALBOX_ENABLE_FORTRAN=OFF')
-        if '+shared' in self.spec:
-            args.append('-DSERIALBOX_BUILD_SHARED=ON')
-        else:
-            args.append('-DSERIALBOX_BUILD_SHARED=OFF')
-        if '~python' in self.spec:
-            args.append('-DSERIALBOX_ENABLE_PYTHON=OFF')
-        if '~sdb' in self.spec:
-            args.append('-DSERIALBOX_ENABLE_SDB=OFF')
-        if '+examples' in self.spec:
-            args.append('-DSERIALBOX_EXAMPLES=ON')
-        else:
-            args.append('-DSERIALBOX_EXAMPLES=OFF')
+            args.append('-DNETCDF_ROOT:PATH=%s' % self.spec['netcdf-c'].prefix)
 
         return args

--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -55,7 +55,7 @@ class Serialbox(CMakePackage):
     depends_on('cmake@3.12:', type='build')
     # We might be provided with an external vanilla cmake, and we need one with
     # with https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
-    depends_on('cmake@3.19:', when='%pgi', type='build')
+    #depends_on('cmake@3.19:', when='%pgi', type='build')
 
     depends_on('boost@1.67.0%gcc', type='build')
     depends_on('boost+filesystem+system',

--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -65,10 +65,10 @@ class Serialbox(CMakePackage):
     depends_on('netcdf-c', when='+netcdf')
 
     # The preprocessor can be run with Python 2:
-    depends_on('python', type='run')
+    #depends_on('python', type=('build','run'))
     # The Python interface is compatible only with Python 3:
-    depends_on('python@3.4:', when='+python', type=('build', 'run'))
-    depends_on('py-numpy', when='+python', type=('build', 'run'))
+    #depends_on('python@3.4:', when='+python', type=('build', 'run'))
+    #depends_on('py-numpy', when='+python', type=('build', 'run'))
 
     # pp_ser fails to process source files containing Unicode character with
     # Python 3 (https://github.com/GridTools/serialbox/pull/249):

--- a/packages/serialbox/ppser_py3.patch
+++ b/packages/serialbox/ppser_py3.patch
@@ -1,0 +1,23 @@
+# This patch is applicable starting version 2.2.1
+--- a/src/serialbox-python/pp_ser/pp_ser.py
++++ b/src/serialbox-python/pp_ser/pp_ser.py
+@@ -51 +51 @@ __email__ = 'oliver.fuhrer@meteoswiss.ch'
+-def to_ascii(text):
++def open23(name, mode='r'):
+@@ -53 +53,9 @@ def to_ascii(text):
+-        return bytes(text, 'ascii')
++        return open(name, mode,
++                    encoding=(None if 'b' in mode else 'UTF-8'))
++    else:
++        return open(name, mode)
++
++
++def bytes23(text):
++    if sys.version_info[0] == 3:
++        return bytes(text, 'UTF-8')
+@@ -815 +823 @@ class PpSer:
+-        input_file = open(os.path.join(self.infile), 'r')
++        input_file = open23(os.path.join(self.infile), 'r')
+@@ -860 +868 @@ class PpSer:
+-            output_file.write(to_ascii(self.__outputBuffer))
++            output_file.write(bytes23(self.__outputBuffer))

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -63,11 +63,7 @@ packages:
     - modules:
       - daint-gpu
       - CMake/3.22.1
-      spec: cmake@3.22.1%gcc
-    - modules:
-      - daint-gpu
-      - CMake/3.22.1
-      spec: cmake@3.22.1%nvhpc
+      spec: cmake@3.22.1
   cosmo:
     compiler:
     - nvhpc@21.3

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -325,7 +325,7 @@ packages:
     - prefix: /usr
       spec: sed@4.4
   serialbox:
-    variants: ~examples
+    variants: ~examples +fortran ~python
   slurm:
     buildable: false
     externals:

--- a/sysconfigs/templates/daint/packages.yaml
+++ b/sysconfigs/templates/daint/packages.yaml
@@ -55,11 +55,7 @@ packages:
   cmake:
     buildable: false
     externals:
-    - spec: cmake@3.22.1%gcc
-      modules:
-      - daint-gpu
-      - CMake/3.22.1
-    - spec: cmake@3.22.1%nvhpc
+    - spec: cmake@3.22.1
       modules:
       - daint-gpu
       - CMake/3.22.1

--- a/sysconfigs/templates/dom/packages.yaml
+++ b/sysconfigs/templates/dom/packages.yaml
@@ -55,11 +55,7 @@ packages:
   cmake:
     buildable: false
     externals:
-    - spec: cmake@3.22.1%gcc
-      modules:
-      - daint-gpu
-      - CMake/3.22.1
-    - spec: cmake@3.22.1%nvhpc
+    - spec: cmake@3.22.1
       modules:
       - daint-gpu
       - CMake/3.22.1

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -11,10 +11,7 @@ packages:
     providers: {}
     compiler: []
     externals:
-    - spec: cmake@3.14.5%gcc
-      modules:
-      - cmake/3.14.5
-    - spec: cmake@3.14.5%pgi
+    - spec: cmake@3.14.5
       modules:
       - cmake/3.14.5
   cuda:

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -116,6 +116,8 @@ packages:
     externals:
     - spec: jasper@1.900.1%gcc +shared
       prefix: /usr
+  serialbox:
+    variants: ~examples +fortran ~python ~sdb
   bzip2:
     externals:
     - spec: bzip2@1.0.6


### PR DESCRIPTION
Repace our current serialbox-package with the one provided by Sergey in Spack.

This change allow to get rid of all hardcoded `cmake%gcc`!

Nonetheless the following modifications with regard to the original implementation were applied:

- Add `cmake_flags.append('-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1')` to flaghandler to account for Daint specialities
- Remove Python as run-dependency (tried to rebuild Python during build)
- Hardcode boost dependency to `depends_on('boost@1.67.0%gcc', type='build')`to avoid a rebuild

This piece of works serves as an sub-step to fully outsource serialbox to the official Spack distribution

**To-Do**

- [x] Manually serialize data from COSMO
- [x] Manually run Dycore test with that data