### PR TITLE
[Test] Split build and test into two parts

### DIFF
--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -186,14 +186,16 @@ Options (spack installcosmo)
 * \--test {root,all}: If root is chosen, run COSMO testsuite before installation 
                      (but skip tests for dependencies). If all is chosen, 
                      run package tests during installation for all packages.
-* -j \--jobs: explicitly set number of parallel jobs
-* \--only {package,dependencies}: select the mode of installation.
+* -j \--jobs: Explicitly set number of parallel jobs
+* \--only {package,dependencies}: Select the mode of installation.
                                  the default is to install the package along with all its dependencies.
                                  alternatively one can decide to install only the package or only
                                  the dependencies.
-* \--keep-stage: don't remove the build after compilation
+* \--keep-stage: Don't remove the build after compilation
 * -v, \--verbose: Verbose installation
 * \--force_uninstall: Force uninstall if COSMO-package is already installed
+* \--dont-restage: If a partial install is detected, don't delete prior
+* -u, \--until: Phase to stop after when installing
 
 Spack dev-build
 ---------------
@@ -261,6 +263,8 @@ Options (spack devbuildcosmo)
                             If all is chosen,
                             run package tests during installation for all packages.
 * -c, \--clean_build: Clean dev-build
+* \--dont-restage: If a partial install is detected, don't delete prior
+* -u, \--until: Phase to stop after when installing
 
 Spack location
 --------------

--- a/sysconfigs/daint/config.yaml
+++ b/sysconfigs/daint/config.yaml
@@ -11,6 +11,5 @@ config:
     root:
   source_cache:
   misc_cache:
-  build_jobs: 4
-  db_lock_timeout: 20
+  build_jobs: 12
   concretizer: original

--- a/sysconfigs/dom/config.yaml
+++ b/sysconfigs/dom/config.yaml
@@ -11,6 +11,5 @@ config:
     root:
   source_cache:
   misc_cache:
-  build_jobs: 4
-  db_lock_timeout: 20
+  build_jobs: 12
   concretizer: original

--- a/sysconfigs/tsa/config.yaml
+++ b/sysconfigs/tsa/config.yaml
@@ -12,5 +12,4 @@ config:
   source_cache:
   misc_cache:
   build_jobs: 6
-  db_lock_timeout: 20
   concretizer: original

--- a/test_spack.py
+++ b/test_spack.py
@@ -69,7 +69,8 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore')
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+            )
             self.Run(
                 'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
             )
@@ -82,7 +83,8 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore')
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+            )
             self.Run(
                 'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
             )
@@ -139,7 +141,8 @@ class CosmoTest(TestCase):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore')
+                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+            )
             self.Srun(
                 'spack installcosmo --dont-restage --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
             )
@@ -376,7 +379,9 @@ class IconToolsTest(TestCase):
     # C2SM supported version
     def test_install(self):
         self.Srun('spack install --until build icontools@c2sm-master%gcc')
-        self.Run('spack install --dont-restage --test=root icontools@c2sm-master%gcc')
+        self.Run(
+            'spack install --dont-restage --test=root icontools@c2sm-master%gcc'
+        )
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -69,7 +69,9 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --test=root cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+            self.Run(
+                'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
             )
         else:
             self.Srun(
@@ -80,7 +82,9 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --test=root cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+            self.Run(
+                'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
             )
         else:
             self.Srun(
@@ -101,7 +105,10 @@ class CosmoTest(TestCase):
         try:
             if machine == 'tsa':
                 self.Srun(
-                    'spack devbuildcosmo --test=root cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
+                    'spack devbuildcosmo --until build cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
+                    cwd='cosmo')
+                self.Run(
+                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
             else:
                 self.Srun(
@@ -116,17 +123,14 @@ class CosmoTest(TestCase):
         try:
             if machine == 'tsa':
                 self.Srun(
-                    'spack devbuildcosmo cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
+                    'spack devbuildcosmo --until build cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
                 self.Run(
-                    'spack devbuildcosmo --test=root cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
+                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
             else:
                 self.Srun(
                     'spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
-                    cwd='cosmo')
-                self.Run(
-                    'spack devbuildcosmo --test=root cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
@@ -135,7 +139,9 @@ class CosmoTest(TestCase):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+            self.Srun(
+                'spack installcosmo --dont-restage --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
             )
 
 
@@ -148,40 +154,40 @@ class CosmoDycoreTest(TestCase):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
+            'spack install --until build cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
         )
         self.Run(
-            'spack install --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
+            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
         )
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
+            'spack install --until build cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
         )
         self.Run(
-            'spack install --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
+            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
         )
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
+            'spack install --until build cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
         )
         self.Run(
-            'spack install --test=root cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
+            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
         )
 
     def test_install_double_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
+            'spack install --until build cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
         )
         self.Run(
-            'spack install --test=root cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
+            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
         )
 
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -27,6 +27,8 @@ class TestCase(unittest.TestCase):
         if parallel:
             if machine == 'tsa':
                 srun = 'srun -c 16 -t 01:00:00'
+            if machine == 'daint':
+                srun = 'srun -C gpu -A g110 -t 01:00:00'
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
@@ -76,7 +78,10 @@ class CosmoTest(TestCase):
             )
         else:
             self.Srun(
-                'spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
+                'spack installcosmo --until build cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
+            )
+            self.Run(
+                'spack installcosmo --dont-restage --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
             )
 
     def test_install_master_cpu(self):
@@ -90,7 +95,10 @@ class CosmoTest(TestCase):
             )
         else:
             self.Srun(
-                'spack installcosmo --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
+                'spack installcosmo --until build cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
+            )
+            self.Run(
+                'spack installcosmo --dont-restage --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
             )
 
     # def test_install_test(self):
@@ -114,7 +122,10 @@ class CosmoTest(TestCase):
                     cwd='cosmo')
             else:
                 self.Srun(
-                    'spack devbuildcosmo --test=root cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
+                    'spack devbuildcosmo --until build cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
+                    cwd='cosmo')
+                self.Run(
+                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
@@ -143,7 +154,7 @@ class CosmoTest(TestCase):
             self.Srun(
                 'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
             )
-            self.Srun(
+            self.Run(
                 'spack installcosmo --dont-restage --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
             )
 
@@ -362,7 +373,10 @@ class Int2lmTest(TestCase):
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.Srun('spack install --test=root int2lm@c2sm-master%nvhpc')
+            self.Srun('spack install --until build int2lm@c2sm-master%nvhpc')
+            self.Run(
+                'spack install --dont-restage --test=root int2lm@c2sm-master%nvhpc'
+            )
 
 
 class IconDuskE2ETest(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -168,40 +168,40 @@ class CosmoDycoreTest(TestCase):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install --until build cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
+            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
         )
         self.Run(
-            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
+            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
         )
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install --until build cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
+            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
         )
         self.Run(
-            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
+            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
         )
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install --until build cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
+            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
         )
         self.Run(
-            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
+            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
         )
 
     def test_install_double_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.Srun(
-            'spack install --until build cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
+            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
         )
         self.Run(
-            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
+            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
         )
 
 
@@ -286,22 +286,22 @@ class IconTest(TestCase):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimicks Buildbot for Tsa)
         if machine == 'tsa':
             self.Srun(
-                'spack install icon@nwp%pgi icon_target=gpu +claw +eccodes +ocean'
+                'spack install --show-log-on-error icon@nwp%pgi icon_target=gpu +claw +eccodes +ocean'
             )
         else:
             self.Srun(
-                'spack install icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
+                'spack install --show-log-on-error icon@nwp%nvhpc icon_target=gpu +claw +eccodes +ocean'
             )
 
     def test_install_nwp_cpu_nvidia(self):
         # So we can make sure ICON-NWP (OpenACC) devs can compile (mimicks Buildbot for Tsa)
         if machine == 'tsa':
             self.Srun(
-                'spack install icon@nwp%pgi icon_target=cpu serialize_mode=create +eccodes +ocean'
+                'spack install --show-log-on-error icon@nwp%pgi icon_target=cpu serialize_mode=create +eccodes +ocean'
             )
         else:
             self.Srun(
-                'spack install icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
+                'spack install --show-log-on-error icon@nwp%nvhpc icon_target=cpu serialize_mode=create +eccodes +ocean'
             )
 
     def test_devbuild_cpu(self):
@@ -349,33 +349,33 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun('spack install --until build int2lm@c2sm-master%pgi')
+            self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%pgi')
             self.Run(
-                'spack install --dont-restage --test=root int2lm@c2sm-master%pgi'
+                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%pgi'
             )
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack install --until build int2lm@org-master%pgi pollen=False'
+                'spack install --show-log-on-error --until build int2lm@org-master%pgi pollen=False'
             )
             self.Run(
-                'spack install --dont-restage --test=root int2lm@org-master%pgi pollen=False'
+                'spack install --show-log-on-error --dont-restage --test=root int2lm@org-master%pgi pollen=False'
             )
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Srun('spack install --until build int2lm@c2sm-master%gcc')
+        self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%gcc')
         self.Run(
-            'spack install --dont-restage --test=root int2lm@c2sm-master%gcc')
+            'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%gcc')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.Srun('spack install --until build int2lm@c2sm-master%nvhpc')
+            self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%nvhpc')
             self.Run(
-                'spack install --dont-restage --test=root int2lm@c2sm-master%nvhpc'
+                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%nvhpc'
             )
 
 
@@ -392,9 +392,9 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.Srun('spack install --until build icontools@c2sm-master%gcc')
+        self.Srun('spack install --show-log-on-error --until build icontools@c2sm-master%gcc')
         self.Run(
-            'spack install --dont-restage --test=root icontools@c2sm-master%gcc'
+            'spack install --show-log-on-error --dont-restage --test=root icontools@c2sm-master%gcc'
         )
 
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -329,17 +329,21 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun('spack install --test=root int2lm@c2sm-master%pgi')
+            self.Srun('spack install --until build int2lm@c2sm-master%pgi')
+            self.Run('spack install --dont-restage --test=root int2lm@c2sm-master%pgi')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack install --test=root int2lm@org-master%pgi pollen=False')
+                'spack install --until build int2lm@org-master%pgi pollen=False')
+            self.Run(
+                'spack install --dont-restage --test=root int2lm@org-master%pgi pollen=False')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Srun('spack install --test=root int2lm@c2sm-master%gcc')
+        self.Srun('spack install --until build int2lm@c2sm-master%gcc')
+        self.Run('spack install --dont-restage --test=root int2lm@c2sm-master%gcc')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22

--- a/test_spack.py
+++ b/test_spack.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 import unittest
 import asyncio
-from random import randint
 
 all_machines = {'daint', 'tsa'}
 
@@ -31,12 +30,9 @@ class TestCase(unittest.TestCase):
             if machine == 'daint':
                 srun = 'srun -C gpu -A g110 -t 01:00:00'
 
-        # randomly delay start of installation to avoid write-locks
-        delay = randint(5, 20)
-
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 import unittest
 import asyncio
+from random import randint
 
 all_machines = {'daint', 'tsa'}
 
@@ -30,9 +31,12 @@ class TestCase(unittest.TestCase):
             if machine == 'daint':
                 srun = 'srun -C gpu -A g110 -t 01:00:00'
 
+        # randomly delay start of installation to avoid write-locks
+        delay = randint(5,20)
+
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} (cd {cwd} ; {srun} {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -32,7 +32,7 @@ class TestCase(unittest.TestCase):
                 srun = 'srun -C gpu -A g110 -t 01:00:00'
 
         # randomly delay start of installation to avoid write-locks
-        delay = randint(5,20)
+        delay = randint(5, 20)
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
@@ -353,7 +353,9 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%pgi')
+            self.Srun(
+                'spack install --show-log-on-error --until build int2lm@c2sm-master%pgi'
+            )
             self.Run(
                 'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%pgi'
             )
@@ -370,14 +372,19 @@ class Int2lmTest(TestCase):
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%gcc')
+        self.Srun(
+            'spack install --show-log-on-error --until build int2lm@c2sm-master%gcc'
+        )
         self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%gcc')
+            'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%gcc'
+        )
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.Srun('spack install --show-log-on-error --until build int2lm@c2sm-master%nvhpc')
+            self.Srun(
+                'spack install --show-log-on-error --until build int2lm@c2sm-master%nvhpc'
+            )
             self.Run(
                 'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%nvhpc'
             )
@@ -396,7 +403,9 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.Srun('spack install --show-log-on-error --until build icontools@c2sm-master%gcc')
+        self.Srun(
+            'spack install --show-log-on-error --until build icontools@c2sm-master%gcc'
+        )
         self.Run(
             'spack install --show-log-on-error --dont-restage --test=root icontools@c2sm-master%gcc'
         )

--- a/test_spack.py
+++ b/test_spack.py
@@ -69,7 +69,7 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore')
             self.Run(
                 'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
             )
@@ -82,7 +82,7 @@ class CosmoTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
+                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore')
             self.Run(
                 'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
             )
@@ -139,7 +139,7 @@ class CosmoTest(TestCase):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
             self.Srun(
-                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
+                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore')
             self.Srun(
                 'spack installcosmo --dont-restage --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
             )
@@ -375,7 +375,8 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.Srun('spack install --test=root icontools@c2sm-master%gcc')
+        self.Srun('spack install --until build icontools@c2sm-master%gcc')
+        self.Run('spack install --dont-restage --test=root icontools@c2sm-master%gcc')
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 import unittest
 import asyncio
+from random import randint
 
 all_machines = {'daint', 'tsa'}
 
@@ -30,9 +31,12 @@ class TestCase(unittest.TestCase):
             if machine == 'daint':
                 srun = 'srun -C gpu -A g110 -t 01:00:00'
 
+        # randomly delay start of installation to avoid write-locks
+        delay = randint(5, 20)
+
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} (cd {cwd} ; {srun} {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -48,6 +48,17 @@ def setup_parser(subparser):
                            action="store_true",
                            help="Clean dev-build")
 
+    subparser.add_argument('--dont-restage',
+                           action='store_false',
+                           dest="restage",
+                           help="if a partial install is detected, don’t delete prior state")
+
+    subparser.add_argument('-u',
+                           '--until',
+                           dest='until',
+                           default=None,
+                           help="phase to stop after when installing (only applies to COSMO)")
+
 
 def custom_devbuild(source_path, spec, args):
     package = spack.repo.get(spec)
@@ -74,7 +85,13 @@ def custom_devbuild(source_path, spec, args):
     else:
         args.things_to_test = False
 
-    kwargs = {'make_jobs': args.jobs, 'tests': args.things_to_test}
+    kwargs = {'make_jobs': args.jobs, 
+              'restage': args.restage,
+              'tests': args.things_to_test}
+
+    # for testing purposes we want to split build and install phase for COSMO
+    if package.name == 'cosmo':
+        kwargs['stop_at'] = args.until
 
     package.do_install(verbose=True, **kwargs)
 

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -48,16 +48,18 @@ def setup_parser(subparser):
                            action="store_true",
                            help="Clean dev-build")
 
-    subparser.add_argument('--dont-restage',
-                           action='store_false',
-                           dest="restage",
-                           help="if a partial install is detected, don’t delete prior state")
+    subparser.add_argument(
+        '--dont-restage',
+        action='store_false',
+        dest="restage",
+        help="if a partial install is detected, don’t delete prior state")
 
-    subparser.add_argument('-u',
-                           '--until',
-                           dest='until',
-                           default=None,
-                           help="phase to stop after when installing (only applies to COSMO)")
+    subparser.add_argument(
+        '-u',
+        '--until',
+        dest='until',
+        default=None,
+        help="phase to stop after when installing (only applies to COSMO)")
 
 
 def custom_devbuild(source_path, spec, args):
@@ -85,9 +87,11 @@ def custom_devbuild(source_path, spec, args):
     else:
         args.things_to_test = False
 
-    kwargs = {'make_jobs': args.jobs, 
-              'restage': args.restage,
-              'tests': args.things_to_test}
+    kwargs = {
+        'make_jobs': args.jobs,
+        'restage': args.restage,
+        'tests': args.things_to_test
+    }
 
     # for testing purposes we want to split build and install phase for COSMO
     if package.name == 'cosmo':

--- a/tools/spack-scripting/scripting/cmd/installcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/installcosmo.py
@@ -63,10 +63,11 @@ the dependencies""")
                            action='store_true',
                            help="force uninstall if package already installed")
 
-    subparser.add_argument('--dont-restage',
-                           action='store_false',
-                           dest="restage",
-                           help="if a partial install is detected, don’t delete prior state")
+    subparser.add_argument(
+        '--dont-restage',
+        action='store_false',
+        dest="restage",
+        help="if a partial install is detected, don’t delete prior state")
 
     subparser.add_argument('-u',
                            '--until',

--- a/tools/spack-scripting/scripting/cmd/installcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/installcosmo.py
@@ -63,6 +63,17 @@ the dependencies""")
                            action='store_true',
                            help="force uninstall if package already installed")
 
+    subparser.add_argument('--dont-restage',
+                           action='store_false',
+                           dest="restage",
+                           help="if a partial install is detected, don’t delete prior state")
+
+    subparser.add_argument('-u',
+                           '--until',
+                           dest='until',
+                           default=None,
+                           help="phase to stop after when installing")
+
 
 def custom_install(spec, args):
     package = spack.repo.get(spec)
@@ -80,7 +91,9 @@ def custom_install(spec, args):
         'install_package': ('package' in args.things_to_install),
         'keep_stage': args.keep_stage,
         'tests': args.things_to_test,
-        'verbose': args.lverbose
+        'verbose': args.lverbose,
+        'stop_at': args.until,
+        'restage': args.restage
     }
 
     if args.things_to_install == 'dependencies':


### PR DESCRIPTION
Currently we do not execute any tests for some packages because Spack
does not run test if a package is already installed:
```python
self.Srun(
            'spack install cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
        )
self.Run(
           'spack install --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
```

In order to still test something we need to do as follows:
```python
        self.Srun(
            'spack install --until build cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
        )
        self.Run(
            'spack install --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
        )
  ```

This PR implements:

- Split build and test into two phases
   - Build on compute nodes
   - Run tests on Login-Nodes
- Use srun on Piz Daint too
- Randomly delay (5-20s) spack command to avoid read/write lock timeouts
- Use default db_lock_timeout on Daint
- increase build-threads to 12

To-Do:

- [x] Extend docs for installcosmo/devbuildcosmo
 