### PR TITLE
[devbuildcosmo] Remove broken mechanism to serialize data

### DIFF
--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -183,16 +183,3 @@ def devbuildcosmo(self, args):
 
     # Dev-build cosmo
     custom_devbuild(source_path, cosmo_spec, args)
-
-    # Serialize data
-    if "+serialize" in cosmo_spec:
-        print("\033[92m" + "==> " + "\033[0m" + "cosmo: Serializing data")
-        try:
-            subprocess.run([
-                source_path + '/cosmo/ACC/test/tools/serialize_cosmo.py',
-                self.spec__str__(), '-b', source_path
-            ],
-                           check=True,
-                           stderr=subprocess.STDOUT)
-        except:
-            tty.die('Serialization failed')


### PR DESCRIPTION
The custom command devbuildcosmo always serializes data if `+serialize` is set.
This is counterintuitive, since for installcosmo there is no such thing in place.

Additionally, it missed the `--spec`argument, therefore it broken anyway and not used by anyone.

We manually call the script in our Jenkins-Plan:
```bash
spack load $SPACK_SPEC
./cosmo/ACC/test/tools/serialize_cosmo.py -s "$SPACK_SPEC" -b "."
```