### PR TITLE
[Daint] run tests on login nodes

### DIFF
--- a/test_spack.py
+++ b/test_spack.py
@@ -30,7 +30,7 @@ class TestCase(unittest.TestCase):
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} (cd {cwd} ; {srun} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 import unittest
 import asyncio
-from random import randint
 
 all_machines = {'daint', 'tsa'}
 
@@ -28,15 +27,10 @@ class TestCase(unittest.TestCase):
         if parallel:
             if machine == 'tsa':
                 srun = 'srun -c 16 -t 01:00:00'
-            if machine == 'daint':
-                srun = 'srun -C gpu -A g110 -t 01:00:00'
-
-        # randomly delay start of installation to avoid write-locks
-        delay = randint(5, 20)
 
         # 2>&1 redirects stderr to stdout
         subprocess.run(
-            f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
+            f'{setup} (cd {cwd} ; {srun} && {command}) >> {machine}_{self.package_name}_{self._testMethodName}.log 2>&1',
             check=True,
             shell=True)
 


### PR DESCRIPTION
Tests report "Timed out waiting for a write lock" on Daint. This blocks other work.
The trick with sleep random doesn't seem to fix it well enough.