### PR TITLE
Sets default host/slave to 'none' and removes values.

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -50,9 +50,8 @@ class CosmoDycore(CMakePackage):
             values=('double', 'float'),
             multi=False)
     variant('slave',
-            default='tsa',
-            description='Build on slave tsa or daint',
-            multi=False)
+            default='nothing',
+            description='Build on slave')
     variant(
         'pmeters',
         default=False,

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -49,7 +49,7 @@ class CosmoDycore(CMakePackage):
             description='Build with double or single precision enabled',
             values=('double', 'float'),
             multi=False)
-    variant('slave', default='nothing', description='Build on slave')
+    variant('slave', default='none', description='Build on slave')
     variant(
         'pmeters',
         default=False,

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -49,9 +49,7 @@ class CosmoDycore(CMakePackage):
             description='Build with double or single precision enabled',
             values=('double', 'float'),
             multi=False)
-    variant('slave',
-            default='nothing',
-            description='Build on slave')
+    variant('slave', default='nothing', description='Build on slave')
     variant(
         'pmeters',
         default=False,

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -102,7 +102,7 @@ class Cosmo(MakefilePackage):
             values=('double', 'float'),
             multi=False)
     variant('claw', default=False, description='Build with claw-compiler')
-    variant('slave', default='nothing', description='Build on slave')
+    variant('slave', default='none', description='Build on slave')
     variant('eccodes',
             default=True,
             description='Build with eccodes instead of grib-api')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -102,9 +102,7 @@ class Cosmo(MakefilePackage):
             values=('double', 'float'),
             multi=False)
     variant('claw', default=False, description='Build with claw-compiler')
-    variant('slave',
-            default='nothing',
-            description='Build on slave')
+    variant('slave', default='nothing', description='Build on slave')
     variant('eccodes',
             default=True,
             description='Build with eccodes instead of grib-api')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -103,9 +103,8 @@ class Cosmo(MakefilePackage):
             multi=False)
     variant('claw', default=False, description='Build with claw-compiler')
     variant('slave',
-            default='tsa',
-            description='Build on slave tsa, daint or kesch',
-            multi=False)
+            default='nothing',
+            description='Build on slave')
     variant('eccodes',
             default=True,
             description='Build with eccodes instead of grib-api')

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -61,10 +61,8 @@ class Icon(Package):
             values=('gpu', 'cpu'),
             multi=False)
     variant('host',
-            default='daint',
-            description='Build on described host (e.g daint)',
-            multi=False,
-            values=('tsa', 'daint'))
+            default='nothing',
+            description='Build on described host (e.g daint)')
     variant('site',
             default='cscs',
             description='Build on described site (e.g cscs)',

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -61,7 +61,7 @@ class Icon(Package):
             values=('gpu', 'cpu'),
             multi=False)
     variant('host',
-            default='nothing',
+            default='none',
             description='Build on described host (e.g daint)')
     variant('site',
             default='cscs',

--- a/packages/icontools/package.py
+++ b/packages/icontools/package.py
@@ -57,7 +57,7 @@ class Icontools(AutotoolsPackage):
     depends_on('jasper@1.900.1%gcc', type=('build', 'link'))
 
     variant('slave',
-            default='nothing',
+            default='none',
             description='Build on described slave (e.g daint)')
     variant('slurm_account',
             default='g110',

--- a/packages/icontools/package.py
+++ b/packages/icontools/package.py
@@ -57,10 +57,8 @@ class Icontools(AutotoolsPackage):
     depends_on('jasper@1.900.1%gcc', type=('build', 'link'))
 
     variant('slave',
-            default='daint',
-            description='Build on described slave (e.g daint)',
-            multi=False,
-            values=('tsa', 'daint'))
+            default='nothing',
+            description='Build on described slave (e.g daint)')
     variant('slurm_account',
             default='g110',
             description=

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -60,7 +60,7 @@ class Int2lm(MakefilePackage):
             description='Build with eccodes instead of grib-api')
     variant('parallel', default=True, description='Build parallel INT2LM')
     variant('pollen', default=True, description='Build with pollen enabled')
-    variant('slave', default='nothing', description='Build on slave')
+    variant('slave', default='none', description='Build on slave')
     variant('verbose', default=False, description='Build with verbose enabled')
 
     conflicts(

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -61,9 +61,8 @@ class Int2lm(MakefilePackage):
     variant('parallel', default=True, description='Build parallel INT2LM')
     variant('pollen', default=True, description='Build with pollen enabled')
     variant('slave',
-            default='tsa',
-            description='Build on slave tsa or daint',
-            multi=False)
+            default='nothing',
+            description='Build on slave')
     variant('verbose', default=False, description='Build with verbose enabled')
 
     conflicts(

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -60,9 +60,7 @@ class Int2lm(MakefilePackage):
             description='Build with eccodes instead of grib-api')
     variant('parallel', default=True, description='Build parallel INT2LM')
     variant('pollen', default=True, description='Build with pollen enabled')
-    variant('slave',
-            default='nothing',
-            description='Build on slave')
+    variant('slave', default='nothing', description='Build on slave')
     variant('verbose', default=False, description='Build with verbose enabled')
 
     conflicts(


### PR DESCRIPTION
By removing the values, any host/slave can be used and the list doesn't require maintenance anymore.
A missing host/slave value can be caught earlier. Potentially when loading config files in ICON. Till now the default value could have caused undesirably long continuation with a bad config.
