### PR TITLE
Int2lm: Advertise c2sm-features branch

### DIFF
--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -31,6 +31,7 @@ class Int2lm(MakefilePackage):
 
     # C2SM tags
     version('c2sm-master', git=c2smgit, branch='master')
+    version('c2sm-features', git=c2smgit, branch='c2sm-features')
     set_versions(version, c2smgit, 'c2sm')
 
     # ORG tags

--- a/test_spack.py
+++ b/test_spack.py
@@ -389,6 +389,16 @@ class Int2lmTest(TestCase):
                 'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%nvhpc'
             )
 
+    def test_install_nvhpc_features(self):
+        # c2sm-features contains some additional functionalities
+        if machine == 'daint':
+            self.Srun(
+                'spack install --show-log-on-error --until build int2lm@c2sm-features%nvhpc'
+            )
+            self.Run(
+                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-features%nvhpc'
+            )
+
 
 class IconDuskE2ETest(TestCase):
     package_name = 'icondusk-e2e'


### PR DESCRIPTION
Advertise the c2sm branch, such that it does not require dev-build.

Depends on: Rename the branch in the C2SM-RCM/int2lm repo from `c2sm` to `c2sm-features` to mirror the cosmo naming scheme.