### PR TITLE
Replaces 'git@github.com:' with 'ssh://git@github.com/'.

### DIFF
--- a/docs/C2SMGuidelines.rst
+++ b/docs/C2SMGuidelines.rst
@@ -37,9 +37,9 @@ The variety of different version-suffix for the cosmo-package:
 
 .. code-block:: python
 
-    git      = 'git@github.com:COSMO-ORG/cosmo.git'
-    apngit   = 'git@github.com:MeteoSwiss-APN/cosmo.git'
-    c2smgit  = 'git@github.com:C2SM-RCM/cosmo.git'
+    git      = 'ssh://git@github.com/COSMO-ORG/cosmo.git'
+    apngit   = 'ssh://git@github.com/MeteoSwiss-APN/cosmo.git'
+    c2smgit  = 'ssh://git@github.com/C2SM-RCM/cosmo.git'
 
     version('org-master', branch='master', get_full_repo=True)
     version('apn-mch', git=apngit, branch='mch', get_full_repo=True)

--- a/docs/Install.rst
+++ b/docs/Install.rst
@@ -41,7 +41,7 @@ Notice the requirements.txt will install all python dependencies required by spa
 
 .. code-block:: bash
 
-    git clone git@github.com:C2SM/spack-c2sm.git
+    git clone ssh://git@github.com/C2SM/spack-c2sm.git
     cd spack-c2sm
     ./config.py -m <machine> -i <spack-installation-directory> -v <version> -r <repos.yaml-installation-directory> -p <spack packages, modules & stages installation-directory> -u <ON or OFF, install upstreams.yaml>
 

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -35,7 +35,9 @@ class CosmoDycore(CMakePackage):
 
     #deprecated
     version('master', branch='master')
-    version('mch', git='ssh://git@github.com/MeteoSwiss-APN/cosmo.git', branch='mch')
+    version('mch',
+            git='ssh://git@github.com/MeteoSwiss-APN/cosmo.git',
+            branch='mch')
 
     variant('build_type',
             default='Release',

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -8,23 +8,23 @@ class CosmoDycore(CMakePackage):
 
     homepage = "https://github.com/COSMO-ORG/cosmo/tree/master/dycore"
 
-    git = "git@github.com:COSMO-ORG/cosmo.git"
-    apngit = "git@github.com:MeteoSwiss-APN/cosmo.git"
-    c2smgit = "git@github.com:C2SM-RCM/cosmo.git"
-    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
+    git = "ssh://git@github.com/COSMO-ORG/cosmo.git"
+    apngit = "ssh://git@github.com/MeteoSwiss-APN/cosmo.git"
+    c2smgit = "ssh://git@github.com/C2SM-RCM/cosmo.git"
+    empagit = 'ssh://git@github.com/C2SM-RCM/cosmo-ghg.git'
 
     maintainers = ['elsagermann']
 
     version('org-master', branch='master')
     version('dev-build', branch='master')
     version('apn-mch',
-            git='git@github.com:MeteoSwiss-APN/cosmo.git',
+            git='ssh://git@github.com/MeteoSwiss-APN/cosmo.git',
             branch='mch')
     version('c2sm-master',
-            git='git@github.com:C2SM-RCM/cosmo.git',
+            git='ssh://git@github.com/C2SM-RCM/cosmo.git',
             branch='master')
     version('c2sm-features',
-            git='git@github.com:C2SM-RCM/cosmo.git',
+            git='ssh://git@github.com/C2SM-RCM/cosmo.git',
             branch='c2sm-features')
     version('empa-ghg', git=empagit, branch='c2sm')
 
@@ -35,7 +35,7 @@ class CosmoDycore(CMakePackage):
 
     #deprecated
     version('master', branch='master')
-    version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch')
+    version('mch', git='ssh://git@github.com/MeteoSwiss-APN/cosmo.git', branch='mch')
 
     variant('build_type',
             default='Release',

--- a/packages/cosmo-eccodes-definitions/package.py
+++ b/packages/cosmo-eccodes-definitions/package.py
@@ -27,8 +27,8 @@ class CosmoEccodesDefinitions(Package):
     """To simplify the usage of the GRIB 2 format within the COSMO Consortium, a COSMO GRIB 2 Policy has been defined. One element of this policy is to define a unified ecCodes system for the COSMO community, which is compatible with all COSMO software. This unified system is split into two parts, the vendor distribution of the ecCodes, available from ECMWF and the modified samples and definitions used by the COSMO consortium, available in the current repository."""
 
     homepage = "https://github.com/COSMO-ORG/eccodes-cosmo-resources.git"
-    url = "git@github.com:COSMO-ORG/eccodes-cosmo-resources.git"
-    git = 'git@github.com:COSMO-ORG/eccodes-cosmo-resources.git'
+    url = "ssh://git@github.com/COSMO-ORG/eccodes-cosmo-resources.git"
+    git = 'ssh://git@github.com/COSMO-ORG/eccodes-cosmo-resources.git'
 
     maintainers = ['egermann']
 

--- a/packages/cosmo-grib-api-definitions/package.py
+++ b/packages/cosmo-grib-api-definitions/package.py
@@ -28,9 +28,9 @@ class CosmoGribApiDefinitions(Package):
 
     # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/elsagermann/libgrib-api-cosmo-resources.git"
-    url = "git@github.com:elsagermann/libgrib-api-cosmo-resources.git"
+    url = "ssh://git@github.com/elsagermann/libgrib-api-cosmo-resources.git"
 
-    git = 'git@github.com:elsagermann/libgrib-api-cosmo-resources.git'
+    git = 'ssh://git@github.com/elsagermann/libgrib-api-cosmo-resources.git'
     maintainers = ['elsagermann']
 
     version('1.20.0.2', commit='06f61f95ca2f5f0ddea668d82429331927ce81dc')

--- a/packages/cosmo-grib-api/package.py
+++ b/packages/cosmo-grib-api/package.py
@@ -12,7 +12,7 @@ class CosmoGribApi(AutotoolsPackage):
        FM-92 GRIB edition 1 and edition 2 messages."""
 
     homepage = 'https://software.ecmwf.int/wiki/display/GRIB/Home'
-    git = 'git@github.com:C2SM-RCM/libgrib-api-vendor.git'
+    git = 'ssh://git@github.com/C2SM-RCM/libgrib-api-vendor.git'
 
     maintainers = ['egermann']
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -13,10 +13,10 @@ class Cosmo(MakefilePackage):
 
     homepage = "http://www.cosmo-model.org"
     url = "https://github.com/MeteoSwiss-APN/cosmo/archive/5.07.mch1.0.p5.tar.gz"
-    git = 'git@github.com:COSMO-ORG/cosmo.git'
-    apngit = 'git@github.com:MeteoSwiss-APN/cosmo.git'
-    c2smgit = 'git@github.com:C2SM-RCM/cosmo.git'
-    empagit = 'git@github.com:C2SM-RCM/cosmo-ghg.git'
+    git = 'ssh://git@github.com/COSMO-ORG/cosmo.git'
+    apngit = 'ssh://git@github.com/MeteoSwiss-APN/cosmo.git'
+    c2smgit = 'ssh://git@github.com/C2SM-RCM/cosmo.git'
+    empagit = 'ssh://git@github.com/C2SM-RCM/cosmo-ghg.git'
     maintainers = ['elsagermann']
 
     version('org-master', branch='master', get_full_repo=True)

--- a/packages/gridtools/package.py
+++ b/packages/gridtools/package.py
@@ -10,7 +10,7 @@ class Gridtools(CMakePackage):
     """The GridTools framework is a set of libraries and utilities to develop performance portable applications in the area of weather and climate."""
 
     homepage = "https://github.com/GridTools/gridtools.git"
-    git = "git@github.com:GridTools/gridtools.git"
+    git = "ssh://git@github.com/GridTools/gridtools.git"
 
     maintainers = ['elsagermann']
 

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -36,7 +36,7 @@ class Icon(Package):
     version('2.0.17', commit='39ed04ad', submodules=True)
     version('exclaim-master',
             branch='master',
-            git='git@github.com:C2SM/icon-exclaim.git',
+            git='ssh://git@github.com/C2SM/icon-exclaim.git',
             submodules=True)
 
     depends_on('cmake')

--- a/packages/icondusk-e2e/package.py
+++ b/packages/icondusk-e2e/package.py
@@ -14,7 +14,7 @@ class IconduskE2e(CMakePackage):
     """A library for numerical weather prediction and climate modelling"""
 
     homepage = 'https://github.com/dawn-ico/icondusk-e2e'
-    git = 'git@github.com:dawn-ico/icondusk-e2e.git'
+    git = 'ssh://git@github.com/dawn-ico/icondusk-e2e.git'
     maintainers = ['cosunae']
 
     version('master', branch='master')

--- a/packages/icontools/package.py
+++ b/packages/icontools/package.py
@@ -26,7 +26,7 @@ class Icontools(AutotoolsPackage):
     """
 
     homepage = 'https://wiki.c2sm.ethz.ch/MODELS/ICONDwdIconTools'
-    c2sm = 'git@github.com:C2SM/icontools.git'
+    c2sm = 'ssh://git@github.com/C2SM/icontools.git'
     dkrz = 'git@gitlab.dkrz.de:dwd-sw/dwd_icon_tools.git'
 
     maintainers = ['jonasjucker']

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -17,9 +17,9 @@ class Int2lm(MakefilePackage):
 
     homepage = "http://www.cosmo-model.org/content/model/"
     url = "https://github.com/MeteoSwiss-APN/int2lm/archive/refs/tags/v2.8.4.tar.gz"
-    git = 'git@github.com:MeteoSwiss-APN/int2lm.git'
-    c2smgit = 'git@github.com:C2SM-RCM/int2lm.git'
-    orggit = 'git@github.com:COSMO-ORG/int2lm.git'
+    git = 'ssh://git@github.com/MeteoSwiss-APN/int2lm.git'
+    c2smgit = 'ssh://git@github.com/C2SM-RCM/int2lm.git'
+    orggit = 'ssh://git@github.com/COSMO-ORG/int2lm.git'
 
     maintainers = ['morsier']
 

--- a/packages/libgrib1/package.py
+++ b/packages/libgrib1/package.py
@@ -27,7 +27,7 @@ class Libgrib1(MakefilePackage):
     """To code / decode the meteorological data to GRIB, special software is needed. While a DWD-written software, the GRIB1-library is used to work with GRIB 1 data, the new application programmers interface grib_api from ECMWF is used for dealing with GRIB 2. But grib_api can also deal with GRIB 1 data. The approach, how data is coded to / decoded from GRIB messages is rather different in these software packages. While the GRIB1-library provides interfaces to code / decode the full GRIB message in one step, the grib_api uses the so-called key/value approach, where the single meta data could be set"""
 
     homepage = "https://github.com/C2SM-RCM/libgrib1"
-    git = "git@github.com:C2SM-RCM/libgrib1.git"
+    git = "ssh://git@github.com/C2SM-RCM/libgrib1.git"
 
     # notify when the package is updated.
     maintainers = ['elsagermann']

--- a/packages/omni-xmod-pool/package.py
+++ b/packages/omni-xmod-pool/package.py
@@ -30,7 +30,7 @@ class OmniXmodPool(Package):
     homepage = "https://www.example.com"
     url = "omni-xmod-pool"
 
-    git = 'git@github.com:claw-project/omni-xmod-pool.git'
+    git = 'ssh://git@github.com/claw-project/omni-xmod-pool.git'
 
     maintainers = ['elsagermann']
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -115,7 +115,7 @@ class CosmoTest(TestCase):
 
     def test_devbuild_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
+        self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
                 self.Srun(
@@ -136,7 +136,7 @@ class CosmoTest(TestCase):
 
     def test_devbuild_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Run('git clone git@github.com:MeteoSwiss-APN/cosmo.git')
+        self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
                 self.Srun(


### PR DESCRIPTION
This is to satisfy spack v0.18.0