### PR TITLE
add variant for icon mixed-precision

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -98,6 +98,7 @@ class Icon(Package):
     variant('ocean', default=True, description='Build with ocean enabled')
     variant('dace', default=False, description='Build with DACE enabled')
     variant('rttov', default=False, description='Build with RTTOV enabled')
+    variant('mixed-precision', default=False, description='Build the ICON dycore in mixed precision')
     variant('silent-rules',
             default=True,
             description='Build with Make silent rules ON')
@@ -186,6 +187,10 @@ class Icon(Package):
         # RTTOV
         if '~rttov' in self.spec:
             args.append('--disable-rttov')
+
+        # Mixed-precision
+        if '+mixed-precision' in self.spec:
+            args.append('--enable-mixed-precision')
 
         # Silent rules
         if '~silent-rules' in self.spec:

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -98,7 +98,9 @@ class Icon(Package):
     variant('ocean', default=True, description='Build with ocean enabled')
     variant('dace', default=False, description='Build with DACE enabled')
     variant('rttov', default=False, description='Build with RTTOV enabled')
-    variant('mixed-precision', default=False, description='Build the ICON dycore in mixed precision')
+    variant('mixed-precision',
+            default=False,
+            description='Build the ICON dycore in mixed precision')
     variant('silent-rules',
             default=True,
             description='Build with Make silent rules ON')


### PR DESCRIPTION
This MR adds a `+mixed-precision` option to the `icon` package.