### PR TITLE
Updates boost dependency.

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -110,7 +110,7 @@ class CosmoDycore(CMakePackage):
 
     depends_on('gridtools@1.1.3 ~cuda', when='~cuda+gt1')
     depends_on('gridtools@1.1.3 +cuda', when='+cuda+gt1')
-    depends_on('boost@1.67.0')
+    depends_on('boost@1.65.1: +program_options +system')
     depends_on('serialbox@2.6.0', when='+build_tests')
     depends_on('mpicuda', type=('build', 'link', 'run'), when='+cuda')
     depends_on('mpi', type=('build', 'link', 'run'), when='~cuda')

--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -57,7 +57,7 @@ class Serialbox(CMakePackage):
     # with https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
     #depends_on('cmake@3.19:', when='%pgi', type='build')
 
-    depends_on('boost@1.67.0%gcc', type='build')
+    depends_on('boost@1.54:', type='build')
     depends_on('boost+filesystem+system',
                when='~std-filesystem',
                type=('build', 'link'))


### PR DESCRIPTION
[cosmo-dycore]
The [documentation](https://github.com/COSMO-ORG/cosmo/tree/master/dycore#requirements) of the cosmo dycore states "Boost (1.65.1 or later)", thus the change.
In spack v0.18.1 the boost package changes, such that explicit "+program_options +system" becomes necessary.

[serialbox]
Mimics [serialbox in spack v0.18.1](https://github.com/spack/spack/blob/v0.18.1/var/spack/repos/builtin/packages/serialbox/package.py#L45)