### PR TITLE
Remove code duplication in test_spack.py

### DIFF
--- a/test_spack.py
+++ b/test_spack.py
@@ -49,16 +49,10 @@ class TestCase(unittest.TestCase):
         else:
             spack_install = 'spack install'
 
-        if '--show-log-on-error' in command:
-            srun = spack_install + ' --show-log-on-error'
-            command = command.replace(' --show-log-on-error', '')
-        else:
-            srun = spack_install
-
-        cmd_build = srun + ' --until build ' + command
+        cmd_build = spack_install + ' --show-log-on-error --until build ' + command
         self.Run(cmd_build, cwd, parallel=True)
 
-        cmd_root = srun + ' --dont-restage --test=root ' + command
+        cmd_root = srun + ' --show-log-on-error --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
     def spack_build_and_test(self, command: str, cwd='.'):
@@ -162,28 +156,28 @@ class CosmoDycoreTest(TestCase):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda --show-log-on-error'
+            'cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
         )
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=float build_type=Release --show-log-on-error +cuda'
+            'cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
         )
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda --show-log-on-error'
+            'cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
         )
 
     def test_install_double_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=double build_type=Release +cuda --show-log-on-error'
+            'cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
         )
 
 
@@ -292,17 +286,17 @@ class IconTestExclaim(TestCase):
 
     def test_install_exclaim_cpu_nvidia(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean --show-log-on-error'
+            'icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean'
         )
 
     def test_install_exclaim_gpu_nvidia(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw --show-log-on-error'
+            'icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw'
         )
 
     def test_install_exclaim_cpu_gcc(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean --show-log-on-error'
+            'icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean'
         )
 
 
@@ -317,30 +311,30 @@ class Int2lmTest(TestCase):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.spack_install_and_test(
-                'int2lm@c2sm-master%pgi --show-log-on-error')
+                'int2lm@c2sm-master%pgi')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
             self.spack_install_and_test(
-                'int2lm@org-master%pgi pollen=False --show-log-on-error')
+                'int2lm@org-master%pgi pollen=False')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         self.spack_install_and_test(
-            'int2lm@c2sm-master%gcc --show-log-on-error')
+            'int2lm@c2sm-master%gcc')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
             self.spack_install_and_test(
-                'int2lm@c2sm-master%nvhpc --show-log-on-error')
+                'int2lm@c2sm-master%nvhpc')
 
     def test_install_nvhpc_features(self):
         # c2sm-features contains some additional functionalities
         if machine == 'daint':
             self.spack_install_and_test(
-                'int2lm@c2sm-features%nvhpc --show-log-on-error')
+                'int2lm@c2sm-features%nvhpc')
 
 
 class IconToolsTest(TestCase):
@@ -351,7 +345,7 @@ class IconToolsTest(TestCase):
     # C2SM supported version
     def test_install(self):
         self.spack_install_and_test(
-            'icontools@c2sm-master%gcc --show-log-on-error')
+            'icontools@c2sm-master%gcc')
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -62,11 +62,12 @@ class TestCase(unittest.TestCase):
         self.Run(cmd_root, cwd)
 
     def spack_build_and_test(self, command: str, cwd='.'):
-        cmd_build = 'spack devbuildcosmo --until build '+command
+        cmd_build = 'spack devbuildcosmo --until build ' + command
         self.Run(cmd_build, cwd, parallel=True)
 
-        cmd_root = 'spack devbuildcosmo --dont-restage --test=root '+command
+        cmd_root = 'spack devbuildcosmo --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
+
 
 class AtlasUtilityTest(TestCase):
     package_name = 'atlas_utilities'

--- a/test_spack.py
+++ b/test_spack.py
@@ -45,7 +45,7 @@ class TestCase(unittest.TestCase):
 
     def spack_install_and_test(self, command: str, cwd='.'):
         if 'cosmo' in command and 'cosmo-dycore' not in command:
-            spack_install = 'spack installcosmo'
+            spack_install = 'spack installcosmo -v'
         else:
             spack_install = 'spack install --show-log-on-error'
 

--- a/test_spack.py
+++ b/test_spack.py
@@ -52,15 +52,16 @@ class TestCase(unittest.TestCase):
             spack_install = 'spack install'
 
         if '--show-log-on-error' in command:
-            srun = spack_install+' --show-log-on-error'
-            command = command.replace(' --show-log-on-error','')
+            srun = spack_install + ' --show-log-on-error'
+            command = command.replace(' --show-log-on-error', '')
         else:
             srun = spack_install
-        cmd_build = srun+' --until build '+command
+        cmd_build = srun + ' --until build ' + command
         self.Run(cmd_build, cwd, parallel=True)
 
-        cmd_root = srun+' --dont-restage --test=root '+command
+        cmd_root = srun + ' --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
+
 
 class AtlasUtilityTest(TestCase):
     package_name = 'atlas_utilities'
@@ -86,16 +87,21 @@ class CosmoTest(TestCase):
     def test_install_master_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test('cosmo@org-master%pgi cosmo_target=gpu +cppdycore')
+            self.spack_install_and_test(
+                'cosmo@org-master%pgi cosmo_target=gpu +cppdycore')
         else:
-            self.spack_install_and_test('cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore')
+            self.spack_install_and_test(
+                'cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore')
 
     def test_install_master_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test('cosmo@org-master%pgi cosmo_target=cpu ~cppdycore')
+            self.spack_install_and_test(
+                'cosmo@org-master%pgi cosmo_target=cpu ~cppdycore')
         else:
-            self.spack_install_and_test('cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore')
+            self.spack_install_and_test(
+                'cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore')
+
     # def test_install_test(self):
     #     # TODO: Decide if we want to integrate this test or not. It has been used lately here: From https://github.com/C2SM/spack-c2sm/pull/289
     #     self.Srun('spack installcosmo --test=root cosmo@master%pgi')
@@ -109,9 +115,13 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_install_and_test('cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore', cwd='cosmo')
+                self.spack_install_and_test(
+                    'cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
+                    cwd='cosmo')
             else:
-                self.spack_install_and_test('cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore', cwd='cosmo')
+                self.spack_install_and_test(
+                    'cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
+                    cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
 
@@ -120,7 +130,9 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_install_and_test('cosmo@dev-build%pgi cosmo_target=gpu +cppdycore', cwd='cosmo')
+                self.spack_install_and_test(
+                    'cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
+                    cwd='cosmo')
             else:
                 self.Srun(
                     'spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
@@ -131,7 +143,8 @@ class CosmoTest(TestCase):
     def test_install_old_version(self):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
-            self.spack_install_and_test('cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore')
+            self.spack_install_and_test(
+                'cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore')
 
 
 class CosmoDycoreTest(TestCase):
@@ -142,22 +155,30 @@ class CosmoDycoreTest(TestCase):
     def test_install_float_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda --show-log-on-error')
+        self.spack_install_and_test(
+            'cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda --show-log-on-error'
+        )
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=float build_type=Release --show-log-on-error +cuda')
+        self.spack_install_and_test(
+            'cosmo-dycore@master%gcc real_type=float build_type=Release --show-log-on-error +cuda'
+        )
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda --show-log-on-error')
+        self.spack_install_and_test(
+            'cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda --show-log-on-error'
+        )
 
     def test_install_double_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=double build_type=Release +cuda --show-log-on-error')
+        self.spack_install_and_test(
+            'cosmo-dycore@master%gcc real_type=double build_type=Release +cuda --show-log-on-error'
+        )
 
 
 class CosmoEccodesDefinitionsTest(TestCase):
@@ -264,13 +285,19 @@ class IconTestExclaim(TestCase):
     machines = 'daint'
 
     def test_install_exclaim_cpu_nvidia(self):
-        self.spack_install_and_test('icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean --show-log-on-error')
+        self.spack_install_and_test(
+            'icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean --show-log-on-error'
+        )
 
     def test_install_exclaim_gpu_nvidia(self):
-        self.spack_install_and_test('icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw --show-log-on-error')
+        self.spack_install_and_test(
+            'icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw --show-log-on-error'
+        )
 
     def test_install_exclaim_cpu_gcc(self):
-        self.spack_install_and_test('icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean --show-log-on-error')
+        self.spack_install_and_test(
+            'icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean --show-log-on-error'
+        )
 
 
 class Int2lmTest(TestCase):
@@ -283,26 +310,31 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test('int2lm@c2sm-master%pgi --show-log-on-error')
+            self.spack_install_and_test(
+                'int2lm@c2sm-master%pgi --show-log-on-error')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test('int2lm@org-master%pgi pollen=False --show-log-on-error')
+            self.spack_install_and_test(
+                'int2lm@org-master%pgi pollen=False --show-log-on-error')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-         self.spack_install_and_test('int2lm@c2sm-master%gcc --show-log-on-error')
+        self.spack_install_and_test(
+            'int2lm@c2sm-master%gcc --show-log-on-error')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.spack_install_and_test('int2lm@c2sm-master%nvhpc --show-log-on-error')
+            self.spack_install_and_test(
+                'int2lm@c2sm-master%nvhpc --show-log-on-error')
 
     def test_install_nvhpc_features(self):
         # c2sm-features contains some additional functionalities
         if machine == 'daint':
-            self.spack_install_and_test('int2lm@c2sm-features%nvhpc --show-log-on-error')
+            self.spack_install_and_test(
+                'int2lm@c2sm-features%nvhpc --show-log-on-error')
 
 
 class IconToolsTest(TestCase):
@@ -312,7 +344,8 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.spack_install_and_test('icontools@c2sm-master%gcc --show-log-on-error')
+        self.spack_install_and_test(
+            'icontools@c2sm-master%gcc --show-log-on-error')
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -50,14 +50,14 @@ class TestCase(unittest.TestCase):
             spack_install = 'spack install'
 
         cmd_build = spack_install + ' --show-log-on-error --until build ' + command
-        self.Run(cmd_build, cwd, parallel=True)
+        self.Srun(cmd_build, cwd)
 
         cmd_root = srun + ' --show-log-on-error --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
     def spack_build_and_test(self, command: str, cwd='.'):
         cmd_build = 'spack devbuildcosmo --until build ' + command
-        self.Run(cmd_build, cwd, parallel=True)
+        self.Srun(cmd_build, cwd)
 
         cmd_root = 'spack devbuildcosmo --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)

--- a/test_spack.py
+++ b/test_spack.py
@@ -43,6 +43,24 @@ class TestCase(unittest.TestCase):
     def Srun(self, command: str, cwd='.'):
         return self.Run(command, cwd, parallel=True)
 
+    def spack_install_and_test(self, command: str, cwd='.'):
+        if 'cosmo@dev-build' in command:
+            spack_install = 'spack devbuildcosmo'
+        elif 'cosmo' in command and 'cosmo-dycore' not in command:
+            spack_install = 'spack installcosmo'
+        else:
+            spack_install = 'spack install'
+
+        if '--show-log-on-error' in command:
+            srun = spack_install+' --show-log-on-error'
+            command = command.replace(' --show-log-on-error','')
+        else:
+            srun = spack_install
+        cmd_build = srun+' --until build '+command
+        self.Run(cmd_build, cwd, parallel=True)
+
+        cmd_root = srun+' --dont-restage --test=root '+command
+        self.Run(cmd_root, cwd)
 
 class AtlasUtilityTest(TestCase):
     package_name = 'atlas_utilities'
@@ -68,37 +86,16 @@ class CosmoTest(TestCase):
     def test_install_master_gpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
-            )
-            self.Run(
-                'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=gpu +cppdycore'
-            )
+            self.spack_install_and_test('cosmo@org-master%pgi cosmo_target=gpu +cppdycore')
         else:
-            self.Srun(
-                'spack installcosmo --until build cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
-            )
-            self.Run(
-                'spack installcosmo --dont-restage --test=root cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore'
-            )
+            self.spack_install_and_test('cosmo@org-master%nvhpc cosmo_target=gpu +cppdycore')
 
     def test_install_master_cpu(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun(
-                'spack installcosmo --until build cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
-            )
-            self.Run(
-                'spack installcosmo --dont-restage --test=root cosmo@org-master%pgi cosmo_target=cpu ~cppdycore'
-            )
+            self.spack_install_and_test('cosmo@org-master%pgi cosmo_target=cpu ~cppdycore')
         else:
-            self.Srun(
-                'spack installcosmo --until build cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
-            )
-            self.Run(
-                'spack installcosmo --dont-restage --test=root cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore'
-            )
-
+            self.spack_install_and_test('cosmo@org-master%nvhpc cosmo_target=cpu ~cppdycore')
     # def test_install_test(self):
     #     # TODO: Decide if we want to integrate this test or not. It has been used lately here: From https://github.com/C2SM/spack-c2sm/pull/289
     #     self.Srun('spack installcosmo --test=root cosmo@master%pgi')
@@ -112,19 +109,9 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.Srun(
-                    'spack devbuildcosmo --until build cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
-                    cwd='cosmo')
-                self.Run(
-                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
-                    cwd='cosmo')
+                self.spack_install_and_test('cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore', cwd='cosmo')
             else:
-                self.Srun(
-                    'spack devbuildcosmo --until build cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
-                    cwd='cosmo')
-                self.Run(
-                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
-                    cwd='cosmo')
+                self.spack_install_and_test('cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore', cwd='cosmo')
         finally:
             self.Run('rm -rf cosmo')
 
@@ -133,12 +120,7 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.Srun(
-                    'spack devbuildcosmo --until build cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
-                    cwd='cosmo')
-                self.Run(
-                    'spack devbuildcosmo --dont-restage --test=root cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
-                    cwd='cosmo')
+                self.spack_install_and_test('cosmo@dev-build%pgi cosmo_target=gpu +cppdycore', cwd='cosmo')
             else:
                 self.Srun(
                     'spack devbuildcosmo cosmo@dev-build%nvhpc cosmo_target=gpu +cppdycore',
@@ -149,12 +131,7 @@ class CosmoTest(TestCase):
     def test_install_old_version(self):
         # So we can reproduce results from old versions.
         if machine == 'tsa':
-            self.Srun(
-                'spack installcosmo --until build cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
-            )
-            self.Run(
-                'spack installcosmo --dont-restage --test=root cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore'
-            )
+            self.spack_install_and_test('cosmo@apn_5.08.mch.1.0.p3%pgi cosmo_target=cpu ~cppdycore')
 
 
 class CosmoDycoreTest(TestCase):
@@ -165,42 +142,22 @@ class CosmoDycoreTest(TestCase):
     def test_install_float_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.Srun(
-            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
-        )
+        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda --show-log-on-error')
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.Srun(
-            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
-        )
+        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=float build_type=Release --show-log-on-error +cuda')
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.Srun(
-            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda'
-        )
+        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=double build_type=Release ~cuda --show-log-on-error')
 
     def test_install_double_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
-        self.Srun(
-            'spack install --show-log-on-error --until build cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root cosmo-dycore@master%gcc real_type=double build_type=Release +cuda'
-        )
+        self.spack_install_and_test('cosmo-dycore@master%gcc real_type=double build_type=Release +cuda --show-log-on-error')
 
 
 class CosmoEccodesDefinitionsTest(TestCase):
@@ -307,28 +264,13 @@ class IconTestExclaim(TestCase):
     machines = 'daint'
 
     def test_install_exclaim_cpu_nvidia(self):
-        self.Srun(
-            'spack install --show-log-on-error --until build --test=root icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean'
-        )
+        self.spack_install_and_test('icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean --show-log-on-error')
 
     def test_install_exclaim_gpu_nvidia(self):
-        self.Srun(
-            'spack install --show-log-on-error --until build --test=root icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw'
-        )
+        self.spack_install_and_test('icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw --show-log-on-error')
 
     def test_install_exclaim_cpu_gcc(self):
-        self.Srun(
-            'spack install --show-log-on-error --until build --test=root icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean'
-        )
+        self.spack_install_and_test('icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean --show-log-on-error')
 
 
 class Int2lmTest(TestCase):
@@ -341,51 +283,26 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun(
-                'spack install --show-log-on-error --until build int2lm@c2sm-master%pgi'
-            )
-            self.Run(
-                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%pgi'
-            )
+            self.spack_install_and_test('int2lm@c2sm-master%pgi --show-log-on-error')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.Srun(
-                'spack install --show-log-on-error --until build int2lm@org-master%pgi pollen=False'
-            )
-            self.Run(
-                'spack install --show-log-on-error --dont-restage --test=root int2lm@org-master%pgi pollen=False'
-            )
+            self.spack_install_and_test('int2lm@org-master%pgi pollen=False --show-log-on-error')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.Srun(
-            'spack install --show-log-on-error --until build int2lm@c2sm-master%gcc'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%gcc'
-        )
+         self.spack_install_and_test('int2lm@c2sm-master%gcc --show-log-on-error')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.Srun(
-                'spack install --show-log-on-error --until build int2lm@c2sm-master%nvhpc'
-            )
-            self.Run(
-                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-master%nvhpc'
-            )
+            self.spack_install_and_test('int2lm@c2sm-master%nvhpc --show-log-on-error')
 
     def test_install_nvhpc_features(self):
         # c2sm-features contains some additional functionalities
         if machine == 'daint':
-            self.Srun(
-                'spack install --show-log-on-error --until build int2lm@c2sm-features%nvhpc'
-            )
-            self.Run(
-                'spack install --show-log-on-error --dont-restage --test=root int2lm@c2sm-features%nvhpc'
-            )
+            self.spack_install_and_test('int2lm@c2sm-features%nvhpc --show-log-on-error')
 
 
 class IconToolsTest(TestCase):
@@ -395,12 +312,7 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.Srun(
-            'spack install --show-log-on-error --until build icontools@c2sm-master%gcc'
-        )
-        self.Run(
-            'spack install --show-log-on-error --dont-restage --test=root icontools@c2sm-master%gcc'
-        )
+        self.spack_install_and_test('icontools@c2sm-master%gcc --show-log-on-error')
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -156,15 +156,13 @@ class CosmoDycoreTest(TestCase):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda'
-        )
+            'cosmo-dycore@master%gcc real_type=float build_type=Release ~cuda')
 
     def test_install_float_gpu(self):
         # The dycore team's PR testing relies on this.
         # The dycore tests launch an srun, therefore the spack command can't be launched in an srun aswell, because sruns don't nest!
         self.spack_install_and_test(
-            'cosmo-dycore@master%gcc real_type=float build_type=Release +cuda'
-        )
+            'cosmo-dycore@master%gcc real_type=float build_type=Release +cuda')
 
     def test_install_double_cpu(self):
         # The dycore team's PR testing relies on this.
@@ -286,18 +284,15 @@ class IconTestExclaim(TestCase):
 
     def test_install_exclaim_cpu_nvidia(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean'
-        )
+            'icon@exclaim-master%nvhpc icon_target=cpu +eccodes +ocean')
 
     def test_install_exclaim_gpu_nvidia(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw'
-        )
+            'icon@exclaim-master%nvhpc icon_target=gpu +eccodes +ocean +claw')
 
     def test_install_exclaim_cpu_gcc(self):
         self.spack_install_and_test(
-            'icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean'
-        )
+            'icon@exclaim-master%gcc icon_target=cpu +eccodes +ocean')
 
 
 class Int2lmTest(TestCase):
@@ -310,31 +305,26 @@ class Int2lmTest(TestCase):
     def test_install_pgi(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test(
-                'int2lm@c2sm-master%pgi')
+            self.spack_install_and_test('int2lm@c2sm-master%pgi')
 
     def test_install_no_pollen(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
         if machine == 'tsa':
-            self.spack_install_and_test(
-                'int2lm@org-master%pgi pollen=False')
+            self.spack_install_and_test('int2lm@org-master%pgi pollen=False')
 
     def test_install_gcc(self):
         # So our quick start tutorial works: https://c2sm.github.io/spack-c2sm/QuickStart.html
-        self.spack_install_and_test(
-            'int2lm@c2sm-master%gcc')
+        self.spack_install_and_test('int2lm@c2sm-master%gcc')
 
     def test_install_nvhpc(self):
         # Replacement of PGI after upgrade of Daint Feb 22
         if machine == 'daint':
-            self.spack_install_and_test(
-                'int2lm@c2sm-master%nvhpc')
+            self.spack_install_and_test('int2lm@c2sm-master%nvhpc')
 
     def test_install_nvhpc_features(self):
         # c2sm-features contains some additional functionalities
         if machine == 'daint':
-            self.spack_install_and_test(
-                'int2lm@c2sm-features%nvhpc')
+            self.spack_install_and_test('int2lm@c2sm-features%nvhpc')
 
 
 class IconToolsTest(TestCase):
@@ -344,8 +334,7 @@ class IconToolsTest(TestCase):
 
     # C2SM supported version
     def test_install(self):
-        self.spack_install_and_test(
-            'icontools@c2sm-master%gcc')
+        self.spack_install_and_test('icontools@c2sm-master%gcc')
 
 
 class LibGrib1Test(TestCase):

--- a/test_spack.py
+++ b/test_spack.py
@@ -44,9 +44,7 @@ class TestCase(unittest.TestCase):
         return self.Run(command, cwd, parallel=True)
 
     def spack_install_and_test(self, command: str, cwd='.'):
-        if 'cosmo@dev-build' in command:
-            spack_install = 'spack devbuildcosmo'
-        elif 'cosmo' in command and 'cosmo-dycore' not in command:
+        if 'cosmo' in command and 'cosmo-dycore' not in command:
             spack_install = 'spack installcosmo'
         else:
             spack_install = 'spack install'
@@ -56,12 +54,19 @@ class TestCase(unittest.TestCase):
             command = command.replace(' --show-log-on-error', '')
         else:
             srun = spack_install
+
         cmd_build = srun + ' --until build ' + command
         self.Run(cmd_build, cwd, parallel=True)
 
         cmd_root = srun + ' --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
+    def spack_build_and_test(self, command: str, cwd='.'):
+        cmd_build = 'spack devbuildcosmo --until build '+command
+        self.Run(cmd_build, cwd, parallel=True)
+
+        cmd_root = 'spack devbuildcosmo --dont-restage --test=root '+command
+        self.Run(cmd_root, cwd)
 
 class AtlasUtilityTest(TestCase):
     package_name = 'atlas_utilities'
@@ -115,11 +120,11 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_install_and_test(
+                self.spack_build_and_test(
                     'cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
             else:
-                self.spack_install_and_test(
+                self.spack_build_and_test(
                     'cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
         finally:
@@ -130,7 +135,7 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_install_and_test(
+                self.spack_build_and_test(
                     'cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
             else:

--- a/test_spack.py
+++ b/test_spack.py
@@ -47,12 +47,12 @@ class TestCase(unittest.TestCase):
         if 'cosmo' in command and 'cosmo-dycore' not in command:
             spack_install = 'spack installcosmo'
         else:
-            spack_install = 'spack install'
+            spack_install = 'spack install --show-log-on-error'
 
-        cmd_build = spack_install + ' --show-log-on-error --until build ' + command
+        cmd_build = spack_install + ' --until build ' + command
         self.Srun(cmd_build, cwd)
 
-        cmd_root = spack_install + ' --show-log-on-error --dont-restage --test=root ' + command
+        cmd_root = spack_install + ' --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
     def spack_devbuild_and_test(self, command: str, cwd='.'):

--- a/test_spack.py
+++ b/test_spack.py
@@ -55,7 +55,7 @@ class TestCase(unittest.TestCase):
         cmd_root = srun + ' --show-log-on-error --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
-    def spack_build_and_test(self, command: str, cwd='.'):
+    def spack_devbuild_and_test(self, command: str, cwd='.'):
         cmd_build = 'spack devbuildcosmo --until build ' + command
         self.Srun(cmd_build, cwd)
 
@@ -115,11 +115,11 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_build_and_test(
+                self.spack_devbuild_and_test(
                     'cosmo@dev-build%pgi cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
             else:
-                self.spack_build_and_test(
+                self.spack_devbuild_and_test(
                     'cosmo@dev-build%nvhpc cosmo_target=cpu ~cppdycore',
                     cwd='cosmo')
         finally:
@@ -130,7 +130,7 @@ class CosmoTest(TestCase):
         self.Run('git clone ssh://git@github.com/MeteoSwiss-APN/cosmo.git')
         try:
             if machine == 'tsa':
-                self.spack_build_and_test(
+                self.spack_devbuild_and_test(
                     'cosmo@dev-build%pgi cosmo_target=gpu +cppdycore',
                     cwd='cosmo')
             else:

--- a/test_spack.py
+++ b/test_spack.py
@@ -52,7 +52,7 @@ class TestCase(unittest.TestCase):
         cmd_build = spack_install + ' --show-log-on-error --until build ' + command
         self.Srun(cmd_build, cwd)
 
-        cmd_root = srun + ' --show-log-on-error --dont-restage --test=root ' + command
+        cmd_root = spack_install + ' --show-log-on-error --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
 
     def spack_devbuild_and_test(self, command: str, cwd='.'):


### PR DESCRIPTION
Added the function spack_install_and_test, which automatically checks if 'spack devbuildcosmo', 'spack installcosmo' or 'spack install' should be used and calls self.Srun and self.Run with the same arguments as before.