### PR TITLE
Moves all failure analysis logic from test_spack.py to send_summary_as_comment_to_PR.py

### DIFF
--- a/send_summary_as_comment_to_PR.py
+++ b/send_summary_as_comment_to_PR.py
@@ -17,7 +17,9 @@ if __name__ == '__main__':
         'https://jenkins-mch.cscs.ch/job/spack_PR/$BUILD_ID/artifact/')
 
     # Trigger phrases that cause a test to get a yellow circle
-    yellow_triggers = ['Timed out waiting for a write lock', 'timed out after 5 seconds']
+    yellow_triggers = [
+        'Timed out waiting for a write lock', 'timed out after 5 seconds'
+    ]
 
     for file_name in glob.glob('*.log'):
         with open(file_name, 'r') as file:

--- a/send_summary_as_comment_to_PR.py
+++ b/send_summary_as_comment_to_PR.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
         'https://jenkins-mch.cscs.ch/job/spack_PR/$BUILD_ID/artifact/')
 
     # Trigger phrases that cause a test to get a yellow circle
-    yellow_triggers = ['Timed out waiting for a write lock']
+    yellow_triggers = ['Timed out waiting for a write lock', 'timed out after 5 seconds']
 
     for file_name in glob.glob('*.log'):
         with open(file_name, 'r') as file:

--- a/send_summary_as_comment_to_PR.py
+++ b/send_summary_as_comment_to_PR.py
@@ -16,16 +16,21 @@ if __name__ == '__main__':
     summary = ResultList(
         'https://jenkins-mch.cscs.ch/job/spack_PR/$BUILD_ID/artifact/')
 
+    # Trigger phrases that cause a test to get a yellow circle
+    yellow_triggers = ['Timed out waiting for a write lock']
+
     for file_name in glob.glob('*.log'):
         with open(file_name, 'r') as file:
             content = file.read()
-            if 'FAIL: TIMEOUT' in content:
-                summary.append(':yellow_circle:', file_name,
-                               '**WRITE LOCK TIMEOUT**')
-            elif 'FAIL: SPACK' in content:
-                summary.append(':red_circle:', file_name)
-            else:
+            if content.endswith('SUCCESS'):
                 summary.append(':green_circle:', file_name)
+            else:
+                for trigger in yellow_triggers:
+                    if trigger in content:
+                        summary.append(':yellow_circle:', file_name, trigger)
+                        break
+                else:
+                    summary.append(':red_circle:', file_name)
 
     # Comment PR
     subprocess.run(

--- a/test_spack.py
+++ b/test_spack.py
@@ -36,22 +36,14 @@ class TestCase(unittest.TestCase):
 
         logfile = f'{machine}_{self.package_name}_{self._testMethodName}.log'
 
-        try:
-            # 2>&1 redirects stderr to stdout
-            subprocess.run(
-                f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {logfile} 2>&1',
-                check=True,
-                shell=True)
+        # 2>&1 redirects stderr to stdout
+        subprocess.run(
+            f'{setup} (cd {cwd} ; {srun} sleep {delay} && {command}) >> {logfile} 2>&1',
+            check=True,
+            shell=True)
 
-        # add reason of fail for summary posted as a comment in PR
-        except Exception as e:
-            timeout_indicator = 'Timed out waiting for a write lock'
-            with open(logfile, 'a') as log:
-                if self.search_str_in_file(logfile, timeout_indicator):
-                    log.write('FAIL: TIMEOUT')
-                else:
-                    log.write('FAIL: SPACK')
-            raise e
+        with open(logfile, 'a') as log:
+            log.write('SUCCESS')
 
     def Srun(self, command: str, cwd='.'):
         return self.Run(command, cwd, parallel=True)
@@ -74,14 +66,6 @@ class TestCase(unittest.TestCase):
 
         cmd_root = 'spack devbuildcosmo --dont-restage --test=root ' + command
         self.Run(cmd_root, cwd)
-
-    def search_str_in_file(self, file_path, word):
-        with open(file_path, 'r') as file:
-            content = file.read()
-            if word in content:
-                return True
-            else:
-                return False
 
 
 class AtlasUtilityTest(TestCase):


### PR DESCRIPTION
Makes use of `str.endswith(..)`.
Provides extensible list of trigger phrases that cause 🟡.