### PR TITLE
[icon] Fix hammoz nml path

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -125,7 +125,7 @@ class Icon(Package):
     @run_before('configure')
     def generate_hammoz_nml(self):
         if '+ham' in self.spec:
-            with working_dir('./externals/atm_phy_echam_submodels/namelists'):
+            with working_dir(self.spec.variants['config_dir'].value + '/externals/atm_phy_echam_submodels/namelists'):
                 make()
 
     def setup_build_environment(self, env):

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -125,7 +125,8 @@ class Icon(Package):
     @run_before('configure')
     def generate_hammoz_nml(self):
         if '+ham' in self.spec:
-            with working_dir(self.spec.variants['config_dir'].value + '/externals/atm_phy_echam_submodels/namelists'):
+            with working_dir(self.spec.variants['config_dir'].value +
+                             '/externals/atm_phy_echam_submodels/namelists'):
                 make()
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
Allows to specify where to look for "externals/atm_phy_echam_submodels/namelists" via setting the config_dir variant.