### PR TITLE
[eccodes] add  version 2.19.0

### DIFF
--- a/packages/eccodes/package.py
+++ b/packages/eccodes/package.py
@@ -5,4 +5,6 @@ from spack.pkg.builtin.eccodes import Eccodes as SpackEccodes
 
 class Eccodes(SpackEccodes):
 
-    version('2.19.0', sha256='a1d080aed1b17a9d4e3aecccc5a328c057830cd4d54f451f5498b80b24c46404')
+    version('2.19.0',
+            sha256=
+            'a1d080aed1b17a9d4e3aecccc5a328c057830cd4d54f451f5498b80b24c46404')

--- a/packages/eccodes/package.py
+++ b/packages/eccodes/package.py
@@ -1,0 +1,8 @@
+from spack.package import *
+
+from spack.pkg.builtin.eccodes import Eccodes as SpackEccodes
+
+
+class Eccodes(SpackEccodes):
+
+    version('2.19.0', sha256='a1d080aed1b17a9d4e3aecccc5a328c057830cd4d54f451f5498b80b24c46404')


### PR DESCRIPTION
Version 2.19.0 is not available as checksummed version in official package.

Therefore Spack used to ask if unsafe version can be fetched. This fails for non-interactive sessions
like pipelines.