### PR TITLE
First attempt at enabling nvhpc@22.5 on Dom

### DIFF
--- a/sysconfigs/dom/compilers.yaml
+++ b/sysconfigs/dom/compilers.yaml
@@ -30,6 +30,22 @@ compilers:
     spec: pgi@21.3.0
     target: any
 - compiler:
+    spec: nvhpc@22.5
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-nvidia
+    - nvidia/22.5
+    - gcc/9.3.0
+    operating_system: cnl7
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    target: any
+- compiler:
     environment: {}
     extra_rpaths: []
     flags: {}

--- a/sysconfigs/dom/packages.yaml
+++ b/sysconfigs/dom/packages.yaml
@@ -4,6 +4,7 @@ packages:
     - gcc@9.3.0
     - gcc@8.3.0
     - nvhpc@21.3
+    - nvhpc@22.5
     - cce@12.0.3
     - gcc@11.2.0
     - intel@2021.3.0
@@ -180,7 +181,7 @@ packages:
       spec: hdf5@1.12.0.4 +mpi +hl
   icon:
     compiler:
-    - nvhpc@21.3
+    - nvhpc@22.5
     - pgi@21.3.0
     - cce@12.0.3
     - gcc@9.3.0

--- a/sysconfigs/dom/packages.yaml
+++ b/sysconfigs/dom/packages.yaml
@@ -73,13 +73,13 @@ packages:
   cosmo:
     compiler:
     - nvhpc@21.3
-    variants: cuda_arch=60 cosmo_target=gpu slave=daint
+    variants: cuda_arch=60 cosmo_target=gpu slave=dom
     version:
     - master
   cosmo-dycore:
     compiler:
     - gcc@8.3.0
-    variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/
+    variants: slave=dom +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/
       slurm_partition= "normal" slurm_bin= "srun" slurm_gpu= "-" slurm_opt_nodes=
       "-N" slurm_nodes= "{0}"  slurm_opt_account= "-A" slurm_account= "g110" slurm_opt_constraint=
       "-C" slurm_constraint= "gpu"
@@ -185,13 +185,13 @@ packages:
     - pgi@21.3.0
     - cce@12.0.3
     - gcc@9.3.0
-    variants: host=daint
+    variants: host=dom
   icontools:
     compiler:
     - gcc
-    variants: slave=daint
+    variants: slave=dom
   int2lm:
-    variants: slave=daint
+    variants: slave=dom
   jemalloc:
     externals:
     - modules:

--- a/sysconfigs/templates/dom/compilers.yaml
+++ b/sysconfigs/templates/dom/compilers.yaml
@@ -30,6 +30,23 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: nvhpc@22.5
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: cnl7
+    target: any
+    modules:
+    - PrgEnv-nvidia
+    - cdt-cuda/22.9
+    - nvidia/22.5
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: nvhpc@21.3
     environment: {}
     extra_rpaths: []
     flags:  {}
@@ -44,5 +61,4 @@ compilers:
       cxx: CC
       f77: ftn
       fc: ftn
-    spec: nvhpc@21.3
     target: any

--- a/sysconfigs/templates/dom/packages.yaml
+++ b/sysconfigs/templates/dom/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
         # default compilers defined by the system
         # these reflect the current installed PE
-    compiler: [gcc@9.3.0, gcc@8.3.0, nvhpc@21.3, cce@12.0.3, gcc@11.2.0,intel@2021.3.0]
+    compiler: [gcc@9.3.0, gcc@8.3.0, nvhpc@21.3, nvhpc@22.5, cce@12.0.3, gcc@11.2.0,intel@2021.3.0]
     providers:
       mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
@@ -30,7 +30,7 @@ packages:
     compiler: [gcc]
   icon:
     variants: host=daint
-    compiler: [nvhpc@21.3, pgi@21.3.0, cce@12.0.3, gcc@9.3.0]
+    compiler: [nvhpc@22.5, pgi@21.3.0, cce@12.0.3, gcc@9.3.0]
   int2lm:
     variants: slave=daint
   netcdf-c:


### PR DESCRIPTION
This will be the first step to transition to nvidia/22.5 on Dom and Daint (after the next upgrade, even if 21.3 will still be supported).  It currently compiles both CPU and GPU with nvidia/22.5.   There are a couple of problems with this configuration:

 * icon@dev-build%nvhpc@22.5 icon_target=cpu  automatically looks for daint.cpu.nvidia, which is a pointer to the proper version, e.g., daint.cpu.nvidia-22.5.0, and similar for icon_target=gpu.   But this is wrong: if anything it should look for $hostname.cpu.nvidia, e.g., dom.cpu.nvidia.   The unacceptable workaround is to create a pointer daint.cpu.nvidia => dom.cpu.nvidia-22.5.0.

 * When run there is an HDF5 incompatibility:  "Headers are 1.12.1, library is 1.12.0" at run time, irrespective of whether 1.12.1 is loaded at run time.  