### PR TITLE
[Daint] Changes for Upgrade Feb 14.

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -284,9 +284,7 @@ class Cosmo(MakefilePackage):
 
         # manually add libs to linker because of broke modules on Piz Daint for nvidia
         else:
-            env.set(
-                'MPIL', '-L' + self.spec['mpi'].prefix +
-                ' -lmpich')
+            env.set('MPIL', '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         env.set('MPII', '-I' + self.mpi_spec.prefix + '/include')
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -283,10 +283,12 @@ class Cosmo(MakefilePackage):
             env.set('MPIL', '-L' + self.mpi_spec.prefix + ' -lmpi_cxx')
 
         # manually add libs to linker because of broke modules on Piz Daint for nvidia
-        else:
+        elif self.spec.variants[
+                'slave'].value == 'daint' and self.compiler.name in ('pgi',
+                                                                     'nvhpc'):
             env.set(
                 'MPIL', '-L' + self.spec['mpi'].prefix +
-                ' -lmpich')
+                ' -lmpich -lnvcpumath -lnvhpcatm')
 
         env.set('MPII', '-I' + self.mpi_spec.prefix + '/include')
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -283,12 +283,10 @@ class Cosmo(MakefilePackage):
             env.set('MPIL', '-L' + self.mpi_spec.prefix + ' -lmpi_cxx')
 
         # manually add libs to linker because of broke modules on Piz Daint for nvidia
-        elif self.spec.variants[
-                'slave'].value == 'daint' and self.compiler.name in ('pgi',
-                                                                     'nvhpc'):
+        else:
             env.set(
                 'MPIL', '-L' + self.spec['mpi'].prefix +
-                ' -lmpich -lnvcpumath -lnvhpcatm')
+                ' -lmpich')
 
         env.set('MPII', '-I' + self.mpi_spec.prefix + '/include')
 

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -129,8 +129,7 @@ class Int2lm(MakefilePackage):
         else:
             env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
             if self.compiler.name != 'gcc':
-                env.set('MPIL',
-                        '-L' + self.spec['mpi'].prefix + ' -lmpich')
+                env.set('MPIL', '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         # Compiler & linker variables
         if self.compiler.name == 'pgi':

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -130,17 +130,8 @@ class Int2lm(MakefilePackage):
             env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
             if self.compiler.name != 'gcc':
 
-                # manually add libs to linker because of broke modules on Piz Daint for nvidia
-                if self.spec.variants[
-                        'slave'].value == 'daint' and self.compiler.name in (
-                            'pgi', 'nvhpc'):
-                    env.set(
-                        'MPIL', '-L' + self.spec['mpi'].prefix +
-                        ' -lmpich -lnvcpumath -lnvhpcatm')
-
-                else:
-                    env.set('MPIL',
-                            '-L' + self.spec['mpi'].prefix + ' -lmpich')
+                env.set('MPIL',
+                        '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         # Compiler & linker variables
         if self.compiler.name == 'pgi':

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -129,18 +129,8 @@ class Int2lm(MakefilePackage):
         else:
             env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
             if self.compiler.name != 'gcc':
-
-                # manually add libs to linker because of broke modules on Piz Daint for nvidia
-                if self.spec.variants[
-                        'slave'].value == 'daint' and self.compiler.name in (
-                            'pgi', 'nvhpc'):
-                    env.set(
-                        'MPIL', '-L' + self.spec['mpi'].prefix +
-                        ' -lmpich -lnvcpumath -lnvhpcatm')
-
-                else:
-                    env.set('MPIL',
-                            '-L' + self.spec['mpi'].prefix + ' -lmpich')
+                env.set('MPIL',
+                        '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         # Compiler & linker variables
         if self.compiler.name == 'pgi':

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -130,8 +130,17 @@ class Int2lm(MakefilePackage):
             env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
             if self.compiler.name != 'gcc':
 
-                env.set('MPIL',
-                        '-L' + self.spec['mpi'].prefix + ' -lmpich')
+                # manually add libs to linker because of broke modules on Piz Daint for nvidia
+                if self.spec.variants[
+                        'slave'].value == 'daint' and self.compiler.name in (
+                            'pgi', 'nvhpc'):
+                    env.set(
+                        'MPIL', '-L' + self.spec['mpi'].prefix +
+                        ' -lmpich -lnvcpumath -lnvhpcatm')
+
+                else:
+                    env.set('MPIL',
+                            '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         # Compiler & linker variables
         if self.compiler.name == 'pgi':

--- a/sysconfigs/dom/compilers.yaml
+++ b/sysconfigs/dom/compilers.yaml
@@ -15,29 +15,17 @@ compilers:
     spec: gcc@8.3.0
     target: any
 - compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-nvidia
-    - nvidia/21.3
-    operating_system: cnl7
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: pgi@21.3.0
-    target: any
-- compiler:
     spec: nvhpc@22.5
     environment: {}
     extra_rpaths: []
-    flags: {}
+    flags:
+      fflags: -lnvcpumath -lnvhpcatm
     modules:
     - PrgEnv-nvidia
     - nvidia/22.5
-    - gcc/9.3.0
+    environment:
+      set:
+        CRAY_NVIDIA_VERSION : 22.5
     operating_system: cnl7
     paths:
       cc: cc
@@ -134,21 +122,6 @@ compilers:
       f77: ftn
       fc: ftn
     spec: intel@2021.3.0
-    target: any
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules:
-    - PrgEnv-nvidia
-    - nvidia/21.3
-    operating_system: cnl7
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    spec: nvhpc@21.3
     target: any
 - compiler:
     environment: {}

--- a/sysconfigs/dom/compilers.yaml
+++ b/sysconfigs/dom/compilers.yaml
@@ -30,6 +30,22 @@ compilers:
     spec: pgi@21.3.0
     target: any
 - compiler:
+    spec: nvhpc@22.5
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-nvidia
+    - nvidia/22.5
+    - gcc/9.3.0
+    operating_system: cnl7
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    target: any
+- compiler:
     environment: {}
     extra_rpaths: []
     flags: {}

--- a/sysconfigs/dom/packages.yaml
+++ b/sysconfigs/dom/packages.yaml
@@ -4,6 +4,7 @@ packages:
     - gcc@9.3.0
     - gcc@8.3.0
     - nvhpc@21.3
+    - nvhpc@22.5
     - cce@12.0.3
     - gcc@11.2.0
     - intel@2021.3.0
@@ -180,7 +181,7 @@ packages:
       spec: hdf5@1.12.0.4 +mpi +hl
   icon:
     compiler:
-    - nvhpc@21.3
+    - nvhpc@22.5
     - pgi@21.3.0
     - cce@12.0.3
     - gcc@9.3.0

--- a/sysconfigs/dom/packages.yaml
+++ b/sysconfigs/dom/packages.yaml
@@ -3,7 +3,6 @@ packages:
     compiler:
     - gcc@9.3.0
     - gcc@8.3.0
-    - nvhpc@21.3
     - nvhpc@22.5
     - cce@12.0.3
     - gcc@11.2.0
@@ -72,7 +71,7 @@ packages:
       spec: cmake@3.22.1
   cosmo:
     compiler:
-    - nvhpc@21.3
+    - nvhpc@22.5
     variants: cuda_arch=60 cosmo_target=gpu slave=daint
     version:
     - master
@@ -182,7 +181,6 @@ packages:
   icon:
     compiler:
     - nvhpc@22.5
-    - pgi@21.3.0
     - cce@12.0.3
     - gcc@9.3.0
     variants: host=daint

--- a/sysconfigs/dom/packages.yaml
+++ b/sysconfigs/dom/packages.yaml
@@ -69,6 +69,9 @@ packages:
       - daint-gpu
       - CMake/3.22.1
       spec: cmake@3.22.1
+    externals:
+      - prefix: /usr
+        spec: cmake@3.17
   cosmo:
     compiler:
     - nvhpc@22.5

--- a/sysconfigs/templates/dom/compilers.yaml
+++ b/sysconfigs/templates/dom/compilers.yaml
@@ -30,6 +30,23 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
+    spec: nvhpc@22.5
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: cnl7
+    target: any
+    modules:
+    - PrgEnv-nvidia
+    - cdt-cuda/22.9
+    - nvidia/22.5
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: nvhpc@21.3
     environment: {}
     extra_rpaths: []
     flags:  {}
@@ -44,5 +61,4 @@ compilers:
       cxx: CC
       f77: ftn
       fc: ftn
-    spec: nvhpc@21.3
     target: any

--- a/sysconfigs/templates/dom/packages.yaml
+++ b/sysconfigs/templates/dom/packages.yaml
@@ -2,7 +2,7 @@ packages:
   all:
         # default compilers defined by the system
         # these reflect the current installed PE
-    compiler: [gcc@9.3.0, gcc@8.3.0, nvhpc@21.3, cce@12.0.3, gcc@11.2.0,intel@2021.3.0]
+    compiler: [gcc@9.3.0, gcc@8.3.0, nvhpc@21.3, nvhpc@22.5, cce@12.0.3, gcc@11.2.0,intel@2021.3.0]
     providers:
       mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
@@ -30,7 +30,7 @@ packages:
     compiler: [gcc]
   icon:
     variants: host=daint
-    compiler: [nvhpc@21.3, pgi@21.3.0, cce@12.0.3, gcc@9.3.0]
+    compiler: [nvhpc@22.5, pgi@21.3.0, cce@12.0.3, gcc@9.3.0]
   int2lm:
     variants: slave=daint
   netcdf-c:


### PR DESCRIPTION
# Current status with nvhpc 22.5

- [x] cosmo-dycore
- [x] cosmo-devbuild
- [x] cosmo-cpu
- [ ] cosmo-gpu
   - one test fails because of bad tolerances

- [ ] icon
   - missing configure-wrapper on ICON side

- [x] infero
- [ ] int2lm
   - gcc ok
   - nvhpc two failing tests because of bad tolerances for all differnt versions

### Ask CSCS support
- Do we use correct combination if cudatoolkit and nvhpc
