### PR TITLE
[test] Adds more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 **.swo
 log/
 env/
-spack-stage/
+spack-build_stage/
+spack-test_stage/
+spack-misc_cache/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,8 @@ pipeline {
                             python3 -m venv env
                             source env/bin/activate
                             pip install -r requirements.txt
+                            . setup-env.sh
+                            spack spec spack
                             """
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
                             python3 -m venv env
                             source env/bin/activate
                             pip install -r requirements.txt
-                            . setup-env.sh
+                            source setup-env.sh
                             spack spec spack
                             """
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,9 @@ pipeline {
                             python3 -m venv env
                             source env/bin/activate
                             pip install -r requirements.txt
-                            setup-env.sh
+                            """
+                            sh """
+                            . setup-env.sh
                             spack spec spack
                             """
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
                             python3 -m venv env
                             source env/bin/activate
                             pip install -r requirements.txt
-                            source setup-env.sh
+                            setup-env.sh
                             spack spec spack
                             """
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,6 @@ pipeline {
                             source env/bin/activate
                             pip install -r requirements.txt
                             """
-                            sh """
-                            ls -als
-                            . setup-env.sh
-                            spack spec spack
-                            """
                         }
                     }
                     stage('Unit Tests') {
@@ -43,6 +38,15 @@ pipeline {
                             mkdir -p log/${NODENAME}/unit_test
                             source env/bin/activate
                             python3 test/unit_test.py ${NODENAME} > log/${NODENAME}/unit_test/summary.log 2>&1
+                            """
+                        }
+                    }
+                    stage('Bootstrap spack') {
+                        steps {
+                            sh """
+                            source env/bin/activate
+                            . ./setup-env.sh
+                            spack spec spack
                             """
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
                             pip install -r requirements.txt
                             """
                             sh """
+                            ls -als
                             . setup-env.sh
                             spack spec spack
                             """

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -36,6 +36,8 @@ class Cosmo(MakefilePackage):
           when='@c2sm-master')
     patch('patches/org-master/spec_as_yaml/patch.test_cosmo',
           when='@org-master')
+    patch('patches/org-master/spec_as_yaml/patch.test_cosmo',
+          when='@6.0')
     # C2SM-FEATURES
     patch('patches/c2sm-features/spec_as_yaml/patch.test_cosmo',
           when='@c2sm-features')
@@ -54,6 +56,8 @@ class Cosmo(MakefilePackage):
           when='@c2sm-master +serialize')
     patch('patches/org-master/spec_as_yaml/patch.serialize_cosmo',
           when='@org-master +serialize')
+    patch('patches/org-master/spec_as_yaml/patch.serialize_cosmo',
+          when='@6.0 +serialize')
     patch('patches/c2sm-features/spec_as_yaml/patch.serialize_cosmo',
           when='@c2sm-features +serialize')
     patch('patches/empa-ghg/spec_as_yaml/patch.serialize_cosmo',

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -36,8 +36,7 @@ class Cosmo(MakefilePackage):
           when='@c2sm-master')
     patch('patches/org-master/spec_as_yaml/patch.test_cosmo',
           when='@org-master')
-    patch('patches/org-master/spec_as_yaml/patch.test_cosmo',
-          when='@6.0')
+    patch('patches/org-master/spec_as_yaml/patch.test_cosmo', when='@6.0')
     # C2SM-FEATURES
     patch('patches/c2sm-features/spec_as_yaml/patch.test_cosmo',
           when='@c2sm-features')

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -39,7 +39,7 @@ class Int2lm(MakefilePackage):
     depends_on('cosmo-eccodes-definitions ^eccodes +fortran',
                type=('build', 'link', 'run'),
                when='+eccodes')
-    depends_on('libgrib1@master', type='build')
+    depends_on('libgrib1 @22-01-2020', type='build')
     depends_on('mpi', type=('build', 'link', 'run'), when='+parallel')
     depends_on('netcdf-c', type=('build', 'link'))
     depends_on('netcdf-fortran', type=('build', 'link'))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 from .format import time_format, sanitized_filename
 from .machine import machine_name
-from .spack_commands import with_spack, log_with_spack
+from .spack_commands import log_with_spack
 from .github import GitHubRepo, Markdown
 from .scope import all_machines, all_packages, explicit_scope, package_triggers

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -49,7 +49,8 @@ if __name__ == "__main__":
             elif 'AssertionError exception when releasing read lock' in content:
                 summary.append(':lock:', test_name, 'spack locking problem')
             elif 'gzip: stdin: decompression OK, trailing garbage ignored' in content:
-                summary.append(':wastebasket:', test_name, 'spack cached archive problem')
+                summary.append(':wastebasket:', test_name,
+                               'spack cached archive problem')
             else:
                 for trigger in yellow_triggers:
                     if trigger in content:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -37,7 +37,6 @@ if __name__ == "__main__":
         'Timed out waiting for a write lock',
         'Timed out waiting for a read lock',
         'timed out after 5 seconds',
-        'AssertionError exception when releasing read lock',
     ]
 
     for file_name in sorted(glob.glob('log/**/*.log', recursive=True)):
@@ -46,6 +45,8 @@ if __name__ == "__main__":
             content = file.read()
             if content.endswith('OK\n'):
                 summary.append(':green_circle:', test_name)
+            elif 'AssertionError exception when releasing read lock' in content:
+                summary.append(':lock:', test_name, trigger)
             else:
                 for trigger in yellow_triggers:
                     if trigger in content:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
         'Timed out waiting for a write lock',
         'Timed out waiting for a read lock',
         'timed out after 5 seconds',
+        'DUE TO TIME LIMIT',  # slurm
     ]
 
     for file_name in sorted(glob.glob('log/**/*.log', recursive=True)):
@@ -46,7 +47,7 @@ if __name__ == "__main__":
             if content.endswith('OK\n'):
                 summary.append(':green_circle:', test_name)
             elif 'AssertionError exception when releasing read lock' in content:
-                summary.append(':lock:', test_name, trigger)
+                summary.append(':lock:', test_name)
             else:
                 for trigger in yellow_triggers:
                     if trigger in content:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -47,7 +47,9 @@ if __name__ == "__main__":
             if content.endswith('OK\n'):
                 summary.append(':green_circle:', test_name)
             elif 'AssertionError exception when releasing read lock' in content:
-                summary.append(':lock:', test_name)
+                summary.append(':lock:', test_name, 'spack locking problem')
+            elif 'gzip: stdin: decompression OK, trailing garbage ignored' in content:
+                summary.append(':wastebasket:', test_name, 'spack cached archive problem')
             else:
                 for trigger in yellow_triggers:
                     if trigger in content:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -34,10 +34,7 @@ if __name__ == "__main__":
 
     # Trigger phrases that cause a test to get a yellow circle
     yellow_triggers = [
-        'Timed out waiting for a write lock',
-        'Timed out waiting for a read lock',
         'timed out after 5 seconds',
-        'DUE TO TIME LIMIT',  # slurm
     ]
 
     for file_name in sorted(glob.glob('log/**/*.log', recursive=True)):
@@ -48,9 +45,15 @@ if __name__ == "__main__":
                 summary.append(':green_circle:', test_name)
             elif 'AssertionError exception when releasing read lock' in content:
                 summary.append(':lock:', test_name, 'spack locking problem')
+            elif 'Timed out waiting for a write lock' in content:
+                summary.append(':lock:', test_name, 'spack write lock problem')
+            elif 'Timed out waiting for a read lock' in content:
+                summary.append(':lock:', test_name, 'spack read lock problem')
             elif 'gzip: stdin: decompression OK, trailing garbage ignored' in content:
                 summary.append(':wastebasket:', test_name,
                                'spack cached archive problem')
+            elif 'DUE TO TIME LIMIT' in content:
+                summary.append(':hourglass:', test_name, 'slurm time limit')
             else:
                 for trigger in yellow_triggers:
                     if trigger in content:

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -52,11 +52,10 @@ def log_with_spack(command: str,
     start = time.time()
     # The output is streamed as directly as possible to the log_file to avoid buffering and potentially losing buffered content.
     # '2>&1' redirects stderr to stdout.
-    ret = subprocess.run(
-        f'{spack_env}; ({srun} {command}) >> {log_file} 2>&1',
-        cwd=cwd,
-        check=False,
-        shell=True)
+    ret = subprocess.run(f'{spack_env}; ({srun} {command}) >> {log_file} 2>&1',
+                         cwd=cwd,
+                         check=False,
+                         shell=True)
     end = time.time()
 
     # Log time and success

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
+from random import randint
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                '..')

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -14,10 +14,11 @@ from .format import time_format, sanitized_filename
 def with_srun(command: str) -> str:
     "Wraps command in 'srun' with machine specific arguments."
 
+    # '-c' should be in sync with sysconfig/<machine>/config.yaml config:build_jobs
     cmd = {
-        'balfrin': 'srun -t 02:00:00',
-        'daint': 'srun -C gpu -A g110 -t 02:00:00',
-        'tsa': 'srun -c 16 -t 02:00:00',
+        'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
+        'daint': 'srun -t 02:00:00 -c 12 -C gpu -A g110',
+        'tsa': 'srun -t 02:00:00 -c 6',
     }[machine_name()]
     return f'{cmd} {command}'
 

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -32,7 +32,7 @@ def log_with_spack(command: str,
         # The '-c' argument should be in sync with
         # sysconfig/<machine>/config.yaml config:build_jobs for max efficiency
         srun = {
-            'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
+            'balfrin': '',
             'daint': 'srun -t 02:00:00 -C gpu -A g110',
             'tsa': 'srun -t 02:00:00 -c 6',
         }[machine_name()]

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -22,7 +22,8 @@ def log_with_spack(command: str,
     If log_filename is None, command is used to create one.
     """
     filename = sanitized_filename(log_filename or command) + '.log'
-    log_file = Path(spack_c2sm_path) / 'log' / machine_name() / test_category / filename
+    log_file = Path(
+        spack_c2sm_path) / 'log' / machine_name() / test_category / filename
 
     # Setup spack env
     spack_env = f'. {spack_c2sm_path}/setup-env.sh'
@@ -38,7 +39,7 @@ def log_with_spack(command: str,
         }[machine_name()]
     else:
         srun_cmd = ''
-        
+
     # Randomly delay
     delay = f'sleep {randint(0, 30)}'
 
@@ -55,10 +56,11 @@ def log_with_spack(command: str,
     start = time.time()
     # The output is streamed as directly as possible to the log_file to avoid buffering and potentially losing buffered content.
     # '2>&1' redirects stderr to stdout.
-    ret = subprocess.run(f'{spack_env}; ({srun} sh -c "{delay}; {command}") >> {log_file} 2>&1',
-                          cwd=cwd,
-                          check=False,
-                          shell=True)
+    ret = subprocess.run(
+        f'{spack_env}; ({srun} sh -c "{delay}; {command}") >> {log_file} 2>&1',
+        cwd=cwd,
+        check=False,
+        shell=True)
     end = time.time()
 
     # Log time and success

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -17,7 +17,7 @@ def with_srun(command: str) -> str:
     # '-c' should be in sync with sysconfig/<machine>/config.yaml config:build_jobs
     cmd = {
         'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
-        'daint': 'srun -t 02:00:00 -c 12 -C gpu -A g110',
+        'daint': 'srun -t 02:00:00 -C gpu -A g110',
         'tsa': 'srun -t 02:00:00 -c 6',
     }[machine_name()]
     return f'{cmd} {command}'

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -32,13 +32,13 @@ def log_with_spack(command: str,
     if srun and getpass.getuser() == 'jenkins':
         # The '-c' argument should be in sync with
         # sysconfig/<machine>/config.yaml config:build_jobs for max efficiency
-        srun_cmd = {
+        srun = {
             'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
             'daint': 'srun -t 02:00:00 -C gpu -A g110',
             'tsa': 'srun -t 02:00:00 -c 6',
         }[machine_name()]
     else:
-        srun_cmd = ''
+        srun = ''
 
     # Randomly delay
     delay = f'sleep {randint(0, 30)}'

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -27,12 +27,12 @@ def log_with_spack(command: str,
     # Setup spack env
     spack_env = f'. {spack_c2sm_path}/setup-env.sh'
 
-    # 'srun' part
+    # Distribute work with 'srun'
     if srun and getpass.getuser() == 'jenkins':
         # The '-c' argument should be in sync with
         # sysconfig/<machine>/config.yaml config:build_jobs for max efficiency
         srun = {
-            'balfrin': '',
+            'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
             'daint': 'srun -t 02:00:00 -C gpu -A g110',
             'tsa': 'srun -t 02:00:00 -c 6',
         }[machine_name()]

--- a/src/spack_commands.py
+++ b/src/spack_commands.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from random import randint
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                '..')
@@ -33,15 +32,12 @@ def log_with_spack(command: str,
         # The '-c' argument should be in sync with
         # sysconfig/<machine>/config.yaml config:build_jobs for max efficiency
         srun = {
-            'balfrin': 'srun -t 02:00:00 -c 12 --partition=normal,postproc',
+            'balfrin': '',
             'daint': 'srun -t 02:00:00 -C gpu -A g110',
             'tsa': 'srun -t 02:00:00 -c 6',
         }[machine_name()]
     else:
         srun = ''
-
-    # Randomly delay
-    delay = f'sleep {randint(0, 30)}'
 
     # Make Directory
     log_file.parent.mkdir(exist_ok=True, parents=True)
@@ -57,7 +53,7 @@ def log_with_spack(command: str,
     # The output is streamed as directly as possible to the log_file to avoid buffering and potentially losing buffered content.
     # '2>&1' redirects stderr to stdout.
     ret = subprocess.run(
-        f'{spack_env}; ({srun} sh -c "{delay}; {command}") >> {log_file} 2>&1',
+        f'{spack_env}; ({srun} {command}) >> {log_file} 2>&1',
         cwd=cwd,
         check=False,
         shell=True)

--- a/sysconfigs/balfrin/config.yaml
+++ b/sysconfigs/balfrin/config.yaml
@@ -5,3 +5,4 @@ config:
   test_stage: '$spack/../spack-test_stage'
   misc_cache: '$spack/../spack-misc_cache'
   build_jobs: 12
+  db_lock_timeout: 120

--- a/sysconfigs/balfrin/config.yaml
+++ b/sysconfigs/balfrin/config.yaml
@@ -1,5 +1,7 @@
 config:
   extensions:
     - '$spack/../tools/spack-scripting'
-  build_stage: '$spack/../spack-stage'
+  build_stage: '$spack/../spack-build_stage'
+  test_stage: '$spack/../spack-test_stage'
+  misc_cache: '$spack/../spack-misc_cache'
   build_jobs: 12

--- a/sysconfigs/daint/config.yaml
+++ b/sysconfigs/daint/config.yaml
@@ -1,7 +1,9 @@
 config:
   extensions:
     - '$spack/../tools/spack-scripting'
-  build_stage: '$spack/../spack-stage'
+  build_stage: '$spack/../spack-build_stage'
+  test_stage: '$spack/../spack-test_stage'
+  misc_cache: '$spack/../spack-misc_cache'
   install_tree:
     projections:
       all: '{name}/{version}/{compiler.name}/{hash}'

--- a/sysconfigs/dom/config.yaml
+++ b/sysconfigs/dom/config.yaml
@@ -1,7 +1,9 @@
 config:
   extensions:
     - '$spack/../tools/spack-scripting'
-  build_stage: '$spack/../spack-stage'
+  build_stage: '$spack/../spack-build_stage'
+  test_stage: '$spack/../spack-test_stage'
+  misc_cache: '$spack/../spack-misc_cache'
   install_tree:
     projections:
       all: '{name}/{version}/{compiler.name}/{hash}'

--- a/sysconfigs/tsa/config.yaml
+++ b/sysconfigs/tsa/config.yaml
@@ -1,7 +1,9 @@
 config:
   extensions:
     - '$spack/../tools/spack-scripting'
-  build_stage: '$spack/../spack-stage'
+  build_stage: '$spack/../spack-build_stage'
+  test_stage: '$spack/../spack-test_stage'
+  misc_cache: '$spack/../spack-misc_cache'
   install_tree:
     projections:
       all: '{name}/{version}/{compiler.name}/{hash}'

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -1,7 +1,6 @@
 packages:
   all:
     compiler: # manually added
-      - nvhpc@21.2
       - gcc@8.3.0
       - pgi@20.4
     providers:

--- a/sysconfigs/unknown/config.yaml
+++ b/sysconfigs/unknown/config.yaml
@@ -1,3 +1,6 @@
 config:
   extensions:
     - '$spack/../tools/spack-scripting'
+  build_stage: '$spack/../spack-build_stage'
+  test_stage: '$spack/../spack-test_stage'
+  misc_cache: '$spack/../spack-misc_cache'

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -10,21 +10,21 @@ sys.path.append(os.path.normpath(spack_c2sm_path))
 from src import machine_name, log_with_spack
 
 
-def spack_info(command: str, log_filename: str = None):
+def spack_info(spec: str, log_filename: str = None):
     """
-    Tests 'spack info' of the given command and writes the output into the log file.
-    If log_filename is None, command is used to create one.
+    Tests 'spack info' of the given spec and writes the output into the log file.
+    If log_filename is None, spec is used to create one.
     """
-    ret = log_with_spack(f'spack info {command}', 'integration_test',
+    ret = log_with_spack(f'spack info {spec}', 'integration_test',
                          log_filename)
 
 
-def spack_spec(command: str, log_filename: str = None):
+def spack_spec(spec: str, log_filename: str = None):
     """
-    Tests 'spack info' of the given command and writes the output into the log file.
-    If log_filename is None, command is used to create one.
+    Tests 'spack info' of the given spec and writes the output into the log file.
+    If log_filename is None, spec is used to create one.
     """
-    ret = log_with_spack(f'spack spec {command}', 'integration_test',
+    ret = log_with_spack(f'spack spec {spec}', 'integration_test',
                          log_filename)
 
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -196,7 +196,8 @@ class CosmoDycoreTest(unittest.TestCase):
 class CosmoEccodesDefinitionsTest(unittest.TestCase):
 
     def test_install_version_2_19_0_7(self):
-        spack_install_and_test('cosmo-eccodes-definitions @2.19.0.7', split_phases=False)
+        spack_install_and_test('cosmo-eccodes-definitions @2.19.0.7',
+                               split_phases=False)
 
 
 @pytest.mark.no_tsa  # It fails with: "This is libtool 2.4.7, but the libtool: definition of this LT_INIT comes from libtool 2.4.2".

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -222,7 +222,8 @@ class CosmoDycoreTest(unittest.TestCase):
 class CosmoEccodesDefinitionsTest(unittest.TestCase):
 
     def test_install_version_2_19_0_7(self):
-        spack_install_and_test_no_phase_splitting('cosmo-eccodes-definitions @2.19.0.7')
+        spack_install_and_test_no_phase_splitting(
+            'cosmo-eccodes-definitions @2.19.0.7')
 
 
 class CosmoGribApiTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -157,7 +157,8 @@ class CosmoTest(unittest.TestCase):
         )
 
     def test_devbuild_version_6_0_cpu(self):
-        unique_folder = uuid.uuid4().hex  # to avoid cloning into the same folder and having race conditions
+        unique_folder = uuid.uuid4(
+        ).hex  # to avoid cloning into the same folder and having race conditions
         subprocess.run(
             f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
             check=True,
@@ -170,7 +171,8 @@ class CosmoTest(unittest.TestCase):
             subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
     def test_devbuild_version_6_0_gpu(self):
-        unique_folder = uuid.uuid4().hex  # to avoid cloning into the same folder and having race conditions
+        unique_folder = uuid.uuid4(
+        ).hex  # to avoid cloning into the same folder and having race conditions
         subprocess.run(
             f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
             check=True,
@@ -181,7 +183,7 @@ class CosmoTest(unittest.TestCase):
                 cwd='cosmo')
         finally:
             subprocess.run(f'rm -rf {unique_folder}', shell=True)
-    
+
     @pytest.mark.no_daint  # Testsuite fails
     def test_install_version_5_09_mch_1_2_p2_cpu(self):
         spack_installcosmo_and_test(
@@ -368,7 +370,7 @@ class PyGt4pyTest(unittest.TestCase):
 
 @pytest.mark.no_balfrin  # py-isort install fails with: No module named 'poetry'.
 @pytest.mark.no_daint  # py-isort install fails
-@pytest.mark.no_tsa # py-isort install fails with: No module named 'poetry'.
+@pytest.mark.no_tsa  # py-isort install fails with: No module named 'poetry'.
 class PyIcon4pyTest(unittest.TestCase):
 
     def test_install_version_main(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -118,12 +118,10 @@ nvidia_compiler: str = {
 @pytest.mark.no_tsa  # irrelevant
 class CosmoTest(unittest.TestCase):
 
-    def test_install_version_6_0_cpu(self):
+    def test_install_version_6_0(self):
         spack_install_and_test(
             f'cosmo @6.0 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}'
         )
-
-    def test_install_version_6_0_gpu(self):
         spack_install_and_test(
             f'cosmo @6.0 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
         )
@@ -181,10 +179,8 @@ class CosmoTest(unittest.TestCase):
 @pytest.mark.no_balfrin  # cuda arch is not supported
 class CosmoDycoreTest(unittest.TestCase):
 
-    def test_install_version_6_0_cuda(self):
+    def test_install_version_6_0(self):
         spack_install_and_test('cosmo-dycore @6.0 +cuda')
-
-    def test_install_version_6_0_no_cuda(self):
         spack_install_and_test('cosmo-dycore @6.0 ~cuda')
 
     def test_install_c2sm_master_cuda(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -1,7 +1,9 @@
 import unittest
 import pytest
+import subprocess
 import sys
 import os
+import uuid
 from pathlib import Path
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -34,7 +36,7 @@ def spack_install_and_test(command: str, log_filename: str = None):
     If log_filename is None, command is used to create one.
     """
     log_filename = sanitized_filename(log_filename or command)
-    log_with_spack(f'spack install --until build -n -v {command}',
+    log_with_spack(f'spack install --until build --test=root -n -v {command}',
                    'system_test',
                    log_filename,
                    srun=True)
@@ -88,6 +90,44 @@ def spack_install_and_test_python_package(command: str,
                    srun=True)
 
 
+def spack_devbuildcosmo_and_test(command: str, log_filename: str = None, cwd = None):
+    """
+    Tests 'spack devbuildcosmo' of the given command and writes the output into the log file.
+    If log_filename is None, command is used to create one.
+    """
+    log_filename = sanitized_filename(log_filename or command)
+    log_with_spack(f'spack devbuildcosmo --until build --test=root -n {command}',
+                   'system_test',
+                   log_filename,
+                   cwd=cwd,
+                   srun=True)
+    log_with_spack(
+        f'spack devbuildcosmo --dont-restage --test=root -n {command}',
+        'system_test',
+        log_filename,
+        cwd=cwd,
+        srun=False)
+
+
+def spack_devbuild_and_test(command: str, log_filename: str = None, cwd = None):
+    """
+    Tests 'spack dev-build' of the given command and writes the output into the log file.
+    If log_filename is None, command is used to create one.
+    """
+    log_filename = sanitized_filename(log_filename or command)
+    log_with_spack(f'spack dev-build --until build --test=root -n {command}',
+                   'system_test',
+                   log_filename,
+                   cwd=cwd,
+                   srun=True)
+    log_with_spack(
+        f'spack dev-build --dont-restage --test=root -n {command}',
+        'system_test',
+        log_filename,
+        cwd=cwd,
+        srun=False)
+
+
 mpi: str = {
     'daint': 'mpich',
     'tsa': 'openmpi',
@@ -101,33 +141,44 @@ nvidia_compiler: str = {
 }[machine_name()]
 
 
+@pytest.mark.no_balfrin  # cosmo-dycore does not support the cuda arch of balfrin
 class CosmoTest(unittest.TestCase):
 
-    # def test_install_version_6_0_cpu(self):
-    #     spack_installcosmo_and_test(
-    #         f'cosmo @6.0 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}'
-    #     )
+    def test_install_version_6_0_cpu(self):
+        spack_installcosmo_and_test(
+            f'cosmo @6.0 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}'
+        )
 
-    # def test_install_version_6_0_gpu(self):
-    #     spack_installcosmo_and_test(
-    #         f'cosmo @6.0 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
-    #     )
+    def test_install_version_6_0_gpu(self):
+        spack_installcosmo_and_test(
+            f'cosmo @6.0 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
+        )
 
-    # def test_devbuild_version_6_0_cpu(self):
-    #     spack_installcosmo_and_test(f'cosmo @6.0 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}')
+    def test_devbuild_version_6_0_cpu(self):
+        unique_folder = uuid.uuid4().hex  # for multiprocessing-safety reasons
+        subprocess.run(f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}', check=True, shell=True)
+        try:
+            spack_devbuildcosmo_and_test(f'cosmo @6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}', cwd=unique_folder)
+        finally:
+            subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
-    # def test_devbuild_version_6_0_gpu(self):
-    #     spack_installcosmo_and_test(f'cosmo @6.0 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}')
+    def test_devbuild_version_6_0_gpu(self):
+        unique_folder = uuid.uuid4().hex  # for multiprocessing-safety reasons
+        subprocess.run(f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}', check=True, shell=True)
+        try:
+            spack_devbuildcosmo_and_test(f'cosmo @6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}', cwd='cosmo')
+        finally:
+            subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
-    # def test_install_version_5_09_mch_1_2_p2_cpu(self):
-    #     spack_installcosmo_and_test(
-    #         f'cosmo @5.09a.mch1.2.p2 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}'
-    #     )
+    def test_install_version_5_09_mch_1_2_p2_cpu(self):
+        spack_installcosmo_and_test(
+            f'cosmo @5.09a.mch1.2.p2 %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}'
+        )
 
-    # def test_install_version_5_09_mch_1_2_p2_gpu(self):
-    #     spack_installcosmo_and_test(
-    #         f'cosmo @5.09a.mch1.2.p2 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
-    #     )
+    def test_install_version_5_09_mch_1_2_p2_gpu(self):
+        spack_installcosmo_and_test(
+            f'cosmo @5.09a.mch1.2.p2 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
+        )
 
     def test_install_c2sm_master_cpu(self):
         spack_installcosmo_and_test(
@@ -140,13 +191,14 @@ class CosmoTest(unittest.TestCase):
         )
 
 
+@pytest.mark.no_balfrin  # cuda arch is not supported
 class CosmoDycoreTest(unittest.TestCase):
 
-    # def test_install_version_6_0_cuda(self):
-    #     spack_install_and_test('cosmo-dycore @6.0 +cuda')
+    def test_install_version_6_0_cuda(self):
+        spack_install_and_test('cosmo-dycore @6.0 +cuda')
 
-    # def test_install_version_6_0_no_cuda(self):
-    #     spack_install_and_test('cosmo-dycore @6.0 ~cuda')
+    def test_install_version_6_0_no_cuda(self):
+        spack_install_and_test('cosmo-dycore @6.0 ~cuda')
 
     def test_install_c2sm_master_cuda(self):
         spack_install_and_test('cosmo-dycore @c2sm-master +cuda')
@@ -189,7 +241,7 @@ class GridToolsTest(unittest.TestCase):
         spack_install_and_test('gridtools @1.1.3')
 
 
-@pytest.mark.no_tsa  # config file does not exist for this machines
+@pytest.mark.no_tsa  # config file does not exist for this machine
 class IconTest(unittest.TestCase):
 
     def test_install_nwp_gpu(self):
@@ -228,11 +280,11 @@ class IconTest(unittest.TestCase):
 
 class Int2lmTest(unittest.TestCase):
 
-    # def test_install_version_3_00_gcc(self):
-    #     spack_install_and_test('int2lm @int2lm-3.00 %gcc')
+    def test_install_version_3_00_gcc(self):
+        spack_install_and_test('int2lm @int2lm-3.00 %gcc')
 
-    # def test_install_version_3_00_nvhpc(self):
-    #     spack_install_and_test(f'int2lm @int2lm-3.00 %{nvidia_compiler}')
+    def test_install_version_3_00_nvhpc(self):
+        spack_install_and_test(f'int2lm @int2lm-3.00 %{nvidia_compiler}')
 
     def test_install_c2sm_master_gcc(self):
         spack_install_and_test(

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -315,6 +315,7 @@ class Int2lmTest(unittest.TestCase):
             'int2lm @c2sm-master %gcc ^eccodes %gcc ^libgrib1 %gcc')
 
     @pytest.mark.no_balfrin  # fails because libgrib1 master fails
+    @pytest.mark.no_tsa  # An error occurred in MPI_Bcast
     def test_install_c2sm_master_nvhpc(self):
         spack_install_and_test(
             f'int2lm @c2sm-master %{nvidia_compiler} ^eccodes %{nvidia_compiler} ^libgrib1 %{nvidia_compiler}'
@@ -355,9 +356,9 @@ class OmniCompilerTest(unittest.TestCase):
         spack_install_and_test('omnicompiler @1.3.2')
 
 
-@pytest.mark.no_balfrin
+@pytest.mark.no_balfrin  # Irrelevant
 @pytest.mark.no_daint  # py-isort install fails with: No module named 'poetry'.
-@pytest.mark.no_tsa
+@pytest.mark.no_tsa  # Irrelevant
 class PyGt4pyTest(unittest.TestCase):
 
     def test_install_version_functional(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -308,6 +308,7 @@ class Int2lmTest(unittest.TestCase):
     def test_install_version_3_00_gcc(self):
         spack_install_and_test('int2lm @int2lm-3.00 %gcc')
 
+    @pytest.mark.no_balfrin  # fails because libgrib1 master fails
     def test_install_version_3_00_nvhpc(self):
         spack_install_and_test(f'int2lm @int2lm-3.00 %{nvidia_compiler}')
 
@@ -315,6 +316,7 @@ class Int2lmTest(unittest.TestCase):
         spack_install_and_test(
             'int2lm @c2sm-master %gcc ^eccodes %gcc ^libgrib1 %gcc')
 
+    @pytest.mark.no_balfrin  # fails because libgrib1 master fails
     def test_install_c2sm_master_nvhpc(self):
         spack_install_and_test(
             f'int2lm @c2sm-master %{nvidia_compiler} ^eccodes %{nvidia_compiler} ^libgrib1 %{nvidia_compiler}'
@@ -329,7 +331,7 @@ class IconToolsTest(unittest.TestCase):
     def test_install(self):
         spack_install_and_test('icontools @c2sm-master %gcc')
 
-
+@pytest.mark.no_balfrin  # This fails with "BOZ literal constant at (1) cannot appear in an array constructor"
 class LibGrib1Test(unittest.TestCase):
 
     def test_install_version_22_01_2020(self):
@@ -373,6 +375,7 @@ class PyIcon4pyTest(unittest.TestCase):
         spack_install_and_test_python_package('py-icon4py @main %gcc')
 
 
+@pytest.mark.no_balfrin  # test fails with warnings
 @pytest.mark.no_daint  # test fails with warnings
 class XcodeMLToolsTest(unittest.TestCase):
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -277,7 +277,7 @@ class IconTest(unittest.TestCase):
         )
 
 
-@pytest.mark.no_balfrin  #  int2lm depends on 'libgrib1 @master', which fails.
+@pytest.mark.no_balfrin  # int2lm depends on 'libgrib1 @22-01-2020', which fails.
 class Int2lmTest(unittest.TestCase):
 
     def test_install_version_3_00_gcc(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -281,7 +281,7 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machines
     def test_install_exclaim_cpu_gcc(self):
         spack_install_and_test(
-            'icon @exclaim-master %gcc icon_target=cpu +eccodes +ocean +claw')
+            'icon @exclaim-master %gcc icon_target=cpu +eccodes +ocean')
 
     @pytest.mark.no_balfrin  # config file does not exist for this machines
     def test_install_exclaim_gpu(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -36,11 +36,11 @@ def spack_install_and_test(command: str, log_filename: str = None):
     If log_filename is None, command is used to create one.
     """
     log_filename = sanitized_filename(log_filename or command)
-    log_with_spack(f'spack install --until build --test=root -n -ddd -vvv {command}',
+    log_with_spack(f'spack -ddd install --until build --test=root -n -v {command}',
                    'system_test',
                    log_filename,
                    srun=True)
-    log_with_spack(f'spack install --dont-restage --test=root -n -ddd -vvv {command}',
+    log_with_spack(f'spack -ddd install --dont-restage --test=root -n -v {command}',
                    'system_test',
                    log_filename,
                    srun=False)

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -249,8 +249,11 @@ class DuskTest(unittest.TestCase):
 
 class GridToolsTest(unittest.TestCase):
 
-    def test_install_version_1_1_3(self):
-        spack_install_and_test('gridtools @1.1.3')
+    def test_install_version_1_1_3_gcc(self):
+        spack_install_and_test('gridtools @1.1.3 %gcc')
+
+    def test_install_version_1_1_3_nvhpc(self):
+        spack_install_and_test(f'gridtools @1.1.3 %{nvidia_compiler}')
 
 
 @pytest.mark.no_tsa  # config file does not exist for this machine

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -277,7 +277,7 @@ class IconTest(unittest.TestCase):
         )
 
 
-@pytest.mark.no_balfrin #  int2lm depends on 'libgrib1 @master', which fails.
+@pytest.mark.no_balfrin  #  int2lm depends on 'libgrib1 @master', which fails.
 class Int2lmTest(unittest.TestCase):
 
     def test_install_version_3_00_gcc(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -330,6 +330,7 @@ class IconToolsTest(unittest.TestCase):
     def test_install(self):
         spack_install_and_test('icontools @c2sm-master %gcc')
 
+
 @pytest.mark.no_balfrin  # This fails with "BOZ literal constant at (1) cannot appear in an array constructor"
 class LibGrib1Test(unittest.TestCase):
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -341,13 +341,13 @@ class OmniCompilerTest(unittest.TestCase):
 class PyGt4pyTest(unittest.TestCase):
 
     def test_install_version_functional(self):
-        spack_install_and_test_python_package('py-gt4py%gcc@8.3.0')
+        spack_install_and_test_python_package('py-gt4py %gcc')
 
 
 class PyIcon4pyTest(unittest.TestCase):
 
     def test_install_version_main(self):
-        spack_install_and_test_python_package('py-icon4py@main%gcc@8.3.0')
+        spack_install_and_test_python_package('py-icon4py @main %gcc')
 
 
 class XcodeMLToolsTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -50,17 +50,17 @@ def spack_install_and_test(spec: str,
 
     if split_phases:
         log_with_spack(
-            f'spack -ddd {command} --until build --test=root -n -v {spec}',
+            f'spack {command} --until build --test=root -n -v {spec}',
             'system_test',
             log_filename,
             srun=True)
         log_with_spack(
-            f'spack -ddd {command} --dont-restage --test=root -n -v {spec}',
+            f'spack {command} --dont-restage --test=root -n -v {spec}',
             'system_test',
             log_filename,
             srun=False)
     else:
-        log_with_spack(f'spack -ddd {command} --test=root -n -v {spec}',
+        log_with_spack(f'spack {command} --test=root -n -v {spec}',
                        'system_test',
                        log_filename,
                        srun=True)

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -167,8 +167,6 @@ class CosmoTest(unittest.TestCase):
             spack_devbuildcosmo_and_test(
                 f'cosmo @dev_build_6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}',
                 cwd=unique_folder)
-        finally:
-            subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
     def test_devbuild_version_6_0_gpu(self):
         unique_folder = uuid.uuid4(
@@ -181,8 +179,6 @@ class CosmoTest(unittest.TestCase):
             spack_devbuildcosmo_and_test(
                 f'cosmo @dev_build_6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}',
                 cwd='cosmo')
-        finally:
-            subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
     @pytest.mark.no_daint  # Testsuite fails
     def test_install_version_5_09_mch_1_2_p2_cpu(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -36,11 +36,11 @@ def spack_install_and_test(command: str, log_filename: str = None):
     If log_filename is None, command is used to create one.
     """
     log_filename = sanitized_filename(log_filename or command)
-    log_with_spack(f'spack install --until build --test=root -n -v {command}',
+    log_with_spack(f'spack install --until build --test=root -n -ddd -vvv {command}',
                    'system_test',
                    log_filename,
                    srun=True)
-    log_with_spack(f'spack install --dont-restage --test=root -n -v {command}',
+    log_with_spack(f'spack install --dont-restage --test=root -n -ddd -vvv {command}',
                    'system_test',
                    log_filename,
                    srun=False)

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -226,6 +226,8 @@ class CosmoEccodesDefinitionsTest(unittest.TestCase):
             'cosmo-eccodes-definitions @2.19.0.7')
 
 
+@pytest.mark.no_tsa  # It fails with: "This is libtool 2.4.7, but the libtool: definition of this LT_INIT comes from libtool 2.4.2".
+@pytest.mark.no_balfrin  # It fails with: "This is libtool 2.4.7, but the libtool: definition of this LT_INIT comes from libtool 2.4.2".
 class CosmoGribApiTest(unittest.TestCase):
 
     def test_install_version_1_20_0_3(self):
@@ -313,6 +315,9 @@ class Int2lmTest(unittest.TestCase):
         )
 
 
+@pytest.mark.no_balfrin  # This fails with "undefined reference to symbol".
+@pytest.mark.no_daint  # This fails with: "C compiler cannot create executables".
+@pytest.mark.no_tsa  # This fails with: "C compiler cannot create executables".
 class IconToolsTest(unittest.TestCase):
 
     def test_install(self):
@@ -335,6 +340,8 @@ class OmniXmodPoolTest(unittest.TestCase):
         spack_install_and_test_no_phase_splitting('omni-xmod-pool @0.1')
 
 
+@pytest.mark.no_balfrin  # This fails with: "multiple definition of symbols"
+@pytest.mark.no_tsa  # This fails with: "multiple definition of symbols"
 class OmniCompilerTest(unittest.TestCase):
 
     def test_install_version_1_3_2(self):
@@ -349,6 +356,8 @@ class PyGt4pyTest(unittest.TestCase):
         spack_install_and_test_python_package('py-gt4py %gcc')
 
 
+@pytest.mark.no_balfrin  # py-isort install fails with: No module named 'poetry'.
+@pytest.mark.no_tsa # py-isort install fails with: No module named 'poetry'.
 class PyIcon4pyTest(unittest.TestCase):
 
     def test_install_version_main(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -222,7 +222,7 @@ class CosmoDycoreTest(unittest.TestCase):
 class CosmoEccodesDefinitionsTest(unittest.TestCase):
 
     def test_install_version_2_19_0_7(self):
-        spack_install_and_test('cosmo-eccodes-definitions @2.19.0.7')
+        spack_install_and_test_no_phase_splitting('cosmo-eccodes-definitions @2.19.0.7')
 
 
 class CosmoGribApiTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -251,7 +251,11 @@ class DuskTest(unittest.TestCase):
 class GridToolsTest(unittest.TestCase):
 
     def test_install_version_1_1_3_gcc(self):
-        spack_install_and_test('gridtools @1.1.3')
+        spack_install_and_test(f'gridtools @1.1.3 %gcc')
+
+    @pytest.mark.no_tsa  # Only pgc++ 18 and 19 are supported! nvhpc doesn't work either.
+    def test_install_version_1_1_3_nvhpc(self):
+        spack_install_and_test(f'gridtools @1.1.3 %{nvidia_compiler}')
 
 
 @pytest.mark.no_tsa  # config file does not exist for this machine

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -359,7 +359,7 @@ class XcodeMLToolsTest(unittest.TestCase):
 class ZLibNGTest(unittest.TestCase):
 
     def test_install_version_2_0_0(self):
-        spack_install_and_test('xcodeml-tools @2.0.0')
+        spack_install_and_test('zlib_ng @2.0.0')
 
 
 if __name__ == '__main__':

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -277,6 +277,7 @@ class IconTest(unittest.TestCase):
         )
 
 
+@pytest.mark.no_balfrin #  int2lm depends on 'libgrib1 @master', which fails.
 class Int2lmTest(unittest.TestCase):
 
     def test_install_version_3_00_gcc(self):
@@ -307,11 +308,15 @@ class IconToolsTest(unittest.TestCase):
         spack_install_and_test('icontools @c2sm-master %gcc')
 
 
-@pytest.mark.no_balfrin  # This fails with "BOZ literal constant at (1) cannot appear in an array constructor"
+@pytest.mark.no_balfrin  # This fails with "BOZ literal constant at (1) cannot appear in an array constructor". https://gcc.gnu.org/onlinedocs/gfortran/BOZ-literal-constants.html
 class LibGrib1Test(unittest.TestCase):
 
     def test_install_version_22_01_2020(self):
         spack_install_and_test('libgrib1 @22-01-2020')
+
+    def test_install_master(self):
+        # int2lm depends on 'libgrib1 @master'
+        spack_install_and_test('libgrib1 @master')
 
 
 class OasisTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -25,7 +25,10 @@ def devirtualize_env():
     os.environ['PATH'] = os.environ['PATH'].replace(virtual_env_bin, '')
 
 
-def spack_install_and_test(spec: str, log_filename: str = None, test_on_login_node = False, python_package = False):
+def spack_install_and_test(spec: str,
+                           log_filename: str = None,
+                           test_on_login_node=False,
+                           python_package=False):
     """
     Tests 'spack install' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
@@ -39,15 +42,14 @@ def spack_install_and_test(spec: str, log_filename: str = None, test_on_login_no
         command = 'install'
 
     if spec.startswith('py-'):
-       python_package = True 
+        python_package = True
 
     if python_package:
         devirtualize_env()
-        log_with_spack(
-            f'spack -ddd {command} --test=root -n -v {spec}',
-            'system_test',
-            log_filename,
-            srun=True)
+        log_with_spack(f'spack -ddd {command} --test=root -n -v {spec}',
+                       'system_test',
+                       log_filename,
+                       srun=True)
     else:
         log_with_spack(
             f'spack -ddd {command} --until build --test=root -n -v {spec}',
@@ -61,7 +63,10 @@ def spack_install_and_test(spec: str, log_filename: str = None, test_on_login_no
             srun=False)
 
 
-def spack_devbuild_and_test(spec: str, log_filename: str = None, cwd = None, python_package = False):
+def spack_devbuild_and_test(spec: str,
+                            log_filename: str = None,
+                            cwd=None,
+                            python_package=False):
     """
     Tests 'spack dev-build' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
@@ -74,26 +79,26 @@ def spack_devbuild_and_test(spec: str, log_filename: str = None, cwd = None, pyt
         command = 'dev-build'
 
     if spec.startswith('py-'):
-       python_package = True 
+        python_package = True
 
     if python_package:
         devirtualize_env()
         log_with_spack(f'spack {command} --test=root -n {spec}',
-            'system_test',
-            log_filename,
-            cwd=cwd,
-            srun=True)
+                       'system_test',
+                       log_filename,
+                       cwd=cwd,
+                       srun=True)
     else:
         log_with_spack(f'spack {command} --until build --test=root -n {spec}',
-            'system_test',
-            log_filename,
-            cwd=cwd,
-            srun=True)
+                       'system_test',
+                       log_filename,
+                       cwd=cwd,
+                       srun=True)
         log_with_spack(f'spack {command} --dont-restage --test=root -n {spec}',
-            'system_test',
-            log_filename,
-            cwd=cwd,
-            srun=False)
+                       'system_test',
+                       log_filename,
+                       cwd=cwd,
+                       srun=False)
 
 
 mpi: str = {

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -144,6 +144,7 @@ nvidia_compiler: str = {
 
 
 @pytest.mark.no_balfrin  # cosmo-dycore does not support the cuda arch of balfrin
+@pytest.mark.no_tsa  # irrelevant
 class CosmoTest(unittest.TestCase):
 
     def test_install_version_6_0_cpu(self):
@@ -156,6 +157,7 @@ class CosmoTest(unittest.TestCase):
             f'cosmo @6.0 %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}'
         )
 
+    @pytest.mark.no_daint  # Patches are not applied. Therefore the tests fail.
     def test_devbuild_version_6_0_cpu(self):
         unique_folder = uuid.uuid4(
         ).hex  # to avoid cloning into the same folder and having race conditions
@@ -167,6 +169,7 @@ class CosmoTest(unittest.TestCase):
             f'cosmo @dev_build_6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}',
             cwd=unique_folder)
 
+    @pytest.mark.no_daint  # Patches are not applied. Therefore the tests fail.
     def test_devbuild_version_6_0_gpu(self):
         unique_folder = uuid.uuid4(
         ).hex  # to avoid cloning into the same folder and having race conditions

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -312,10 +312,6 @@ class LibGrib1Test(unittest.TestCase):
     def test_install_version_22_01_2020(self):
         spack_install_and_test('libgrib1 @22-01-2020')
 
-    def test_install_master(self):
-        # int2lm depends on 'libgrib1 @master'
-        spack_install_and_test('libgrib1 @master')
-
 
 class OasisTest(unittest.TestCase):
     pass

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -90,17 +90,20 @@ def spack_install_and_test_python_package(command: str,
                    srun=True)
 
 
-def spack_devbuildcosmo_and_test(command: str, log_filename: str = None, cwd = None):
+def spack_devbuildcosmo_and_test(command: str,
+                                 log_filename: str = None,
+                                 cwd=None):
     """
     Tests 'spack devbuildcosmo' of the given command and writes the output into the log file.
     If log_filename is None, command is used to create one.
     """
     log_filename = sanitized_filename(log_filename or command)
-    log_with_spack(f'spack devbuildcosmo --until build --test=root -n {command}',
-                   'system_test',
-                   log_filename,
-                   cwd=cwd,
-                   srun=True)
+    log_with_spack(
+        f'spack devbuildcosmo --until build --test=root -n {command}',
+        'system_test',
+        log_filename,
+        cwd=cwd,
+        srun=True)
     log_with_spack(
         f'spack devbuildcosmo --dont-restage --test=root -n {command}',
         'system_test',
@@ -109,7 +112,7 @@ def spack_devbuildcosmo_and_test(command: str, log_filename: str = None, cwd = N
         srun=False)
 
 
-def spack_devbuild_and_test(command: str, log_filename: str = None, cwd = None):
+def spack_devbuild_and_test(command: str, log_filename: str = None, cwd=None):
     """
     Tests 'spack dev-build' of the given command and writes the output into the log file.
     If log_filename is None, command is used to create one.
@@ -120,12 +123,11 @@ def spack_devbuild_and_test(command: str, log_filename: str = None, cwd = None):
                    log_filename,
                    cwd=cwd,
                    srun=True)
-    log_with_spack(
-        f'spack dev-build --dont-restage --test=root -n {command}',
-        'system_test',
-        log_filename,
-        cwd=cwd,
-        srun=False)
+    log_with_spack(f'spack dev-build --dont-restage --test=root -n {command}',
+                   'system_test',
+                   log_filename,
+                   cwd=cwd,
+                   srun=False)
 
 
 mpi: str = {
@@ -156,17 +158,27 @@ class CosmoTest(unittest.TestCase):
 
     def test_devbuild_version_6_0_cpu(self):
         unique_folder = uuid.uuid4().hex  # for multiprocessing-safety reasons
-        subprocess.run(f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}', check=True, shell=True)
+        subprocess.run(
+            f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
+            check=True,
+            shell=True)
         try:
-            spack_devbuildcosmo_and_test(f'cosmo @6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}', cwd=unique_folder)
+            spack_devbuildcosmo_and_test(
+                f'cosmo @6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}',
+                cwd=unique_folder)
         finally:
             subprocess.run(f'rm -rf {unique_folder}', shell=True)
 
     def test_devbuild_version_6_0_gpu(self):
         unique_folder = uuid.uuid4().hex  # for multiprocessing-safety reasons
-        subprocess.run(f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}', check=True, shell=True)
+        subprocess.run(
+            f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
+            check=True,
+            shell=True)
         try:
-            spack_devbuildcosmo_and_test(f'cosmo @6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}', cwd='cosmo')
+            spack_devbuildcosmo_and_test(
+                f'cosmo @6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}',
+                cwd='cosmo')
         finally:
             subprocess.run(f'rm -rf {unique_folder}', shell=True)
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -217,7 +217,7 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machines
     def test_install_exclaim_cpu_gcc(self):
         spack_install_and_test(
-            'icon @exclaim-master %gcc icon_target=gpu +eccodes +ocean +claw')
+            'icon @exclaim-master %gcc icon_target=cpu +eccodes +ocean +claw')
 
     @pytest.mark.no_balfrin  # config file does not exist for this machines
     def test_install_exclaim_gpu(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -27,7 +27,7 @@ def devirtualize_env():
 
 def spack_install_and_test(spec: str,
                            log_filename: str = None,
-                           test_on_login_node=False,
+                           split_phases=True,
                            python_package=False):
     """
     Tests 'spack install' of the given spec and writes the output into the log file.
@@ -45,12 +45,10 @@ def spack_install_and_test(spec: str,
         python_package = True
 
     if python_package:
+        split_phases = True
         devirtualize_env()
-        log_with_spack(f'spack -ddd {command} --test=root -n -v {spec}',
-                       'system_test',
-                       log_filename,
-                       srun=True)
-    else:
+
+    if split_phases:
         log_with_spack(
             f'spack -ddd {command} --until build --test=root -n -v {spec}',
             'system_test',
@@ -61,6 +59,11 @@ def spack_install_and_test(spec: str,
             'system_test',
             log_filename,
             srun=False)
+    else:
+        log_with_spack(f'spack -ddd {command} --test=root -n -v {spec}',
+                       'system_test',
+                       log_filename,
+                       srun=True)
 
 
 def spack_devbuild_and_test(spec: str,
@@ -193,8 +196,7 @@ class CosmoDycoreTest(unittest.TestCase):
 class CosmoEccodesDefinitionsTest(unittest.TestCase):
 
     def test_install_version_2_19_0_7(self):
-        spack_install_and_test_no_phase_splitting(
-            'cosmo-eccodes-definitions @2.19.0.7')
+        spack_install_and_test('cosmo-eccodes-definitions @2.19.0.7', split_phases=False)
 
 
 @pytest.mark.no_tsa  # It fails with: "This is libtool 2.4.7, but the libtool: definition of this LT_INIT comes from libtool 2.4.2".
@@ -322,7 +324,7 @@ class OasisTest(unittest.TestCase):
 class OmniXmodPoolTest(unittest.TestCase):
 
     def test_install_version_0_1(self):
-        spack_install_and_test_no_phase_splitting('omni-xmod-pool @0.1')
+        spack_install_and_test('omni-xmod-pool @0.1', split_phases=False)
 
 
 @pytest.mark.no_balfrin  # This fails with: "multiple definition of symbols"

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -163,10 +163,9 @@ class CosmoTest(unittest.TestCase):
             f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
             check=True,
             shell=True)
-        try:
-            spack_devbuildcosmo_and_test(
-                f'cosmo @dev_build_6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}',
-                cwd=unique_folder)
+        spack_devbuildcosmo_and_test(
+            f'cosmo @dev_build_6.0_cpu %{nvidia_compiler} cosmo_target=cpu ~cppdycore ^{mpi} %{nvidia_compiler}',
+            cwd=unique_folder)
 
     def test_devbuild_version_6_0_gpu(self):
         unique_folder = uuid.uuid4(
@@ -175,10 +174,9 @@ class CosmoTest(unittest.TestCase):
             f'git clone --depth 1 --branch 6.0 git@github.com:COSMO-ORG/cosmo.git {unique_folder}',
             check=True,
             shell=True)
-        try:
-            spack_devbuildcosmo_and_test(
-                f'cosmo @dev_build_6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}',
-                cwd='cosmo')
+        spack_devbuildcosmo_and_test(
+            f'cosmo @dev_build_6.0_gpu %{nvidia_compiler} cosmo_target=gpu +cppdycore ^{mpi} %{nvidia_compiler}',
+            cwd='cosmo')
 
     @pytest.mark.no_daint  # Testsuite fails
     def test_install_version_5_09_mch_1_2_p2_cpu(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -36,14 +36,16 @@ def spack_install_and_test(command: str, log_filename: str = None):
     If log_filename is None, command is used to create one.
     """
     log_filename = sanitized_filename(log_filename or command)
-    log_with_spack(f'spack -ddd install --until build --test=root -n -v {command}',
-                   'system_test',
-                   log_filename,
-                   srun=True)
-    log_with_spack(f'spack -ddd install --dont-restage --test=root -n -v {command}',
-                   'system_test',
-                   log_filename,
-                   srun=False)
+    log_with_spack(
+        f'spack -ddd install --until build --test=root -n -v {command}',
+        'system_test',
+        log_filename,
+        srun=True)
+    log_with_spack(
+        f'spack -ddd install --dont-restage --test=root -n -v {command}',
+        'system_test',
+        log_filename,
+        srun=False)
 
 
 def spack_install_and_test_no_phase_splitting(command: str,

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -250,10 +250,7 @@ class DuskTest(unittest.TestCase):
 class GridToolsTest(unittest.TestCase):
 
     def test_install_version_1_1_3_gcc(self):
-        spack_install_and_test('gridtools @1.1.3 %gcc')
-
-    def test_install_version_1_1_3_nvhpc(self):
-        spack_install_and_test(f'gridtools @1.1.3 %{nvidia_compiler}')
+        spack_install_and_test('gridtools @1.1.3')
 
 
 @pytest.mark.no_tsa  # config file does not exist for this machine


### PR DESCRIPTION
Localizes 'test_stage' and 'misc_cache'.
Adds Jenkins stage 'Bootstrap spack' to mitigate race condition on it.
[tsa] Removes nvhpc from packages:all:compiler.
[int2lm] Changes dependency on libgrib1@master to libgrib@22-01-2020. They are the same commit ATM.
Refactoring of spack_commands.py, integration_test.py and 'spack_install_and_test(..)'
Improves test reports.
Removes 'srun' for Balfrin to avoid Spack locking problems.
Adds patches for cosmo @6.0
Adds tests for

- cosmo @6.0 (install and dev-build)
- cosmo @5.09a.mch1.2.p2
- cosmo-dycore @6.0
- gridtools @1.1.3 %nvidia_compiler
- int2lm @int2lm-3.00 %gcc
- int2lm @int2lm-3.00 %nvidia_compiler
- zlib_ng @2.0.0

Deactivates failing tests.