### PR TITLE
[claw] Adds version 2.1

### DIFF
--- a/packages/claw/package.py
+++ b/packages/claw/package.py
@@ -1,0 +1,6 @@
+from spack import *
+from spack.pkg.builtin.Claw import Claw as SpackClaw
+
+
+class Claw(SpackClaw):
+    version('2.1', tag='v2.1', submodules=True)


### PR DESCRIPTION
spack-c2sm master had claw@2.1: https://github.com/C2SM/spack-c2sm/blob/master/packages/claw/package.py#L19
and COSMO needs it: https://github.com/COSMO-ORG/cosmo/blob/6.0/cosmo/ACC/spack/spec.yaml#L3