### PR TITLE
[tsa] fixes external prefix of openjdk.

### DIFF
--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -140,8 +140,8 @@ packages:
       prefix: /usr
   openjdk:
     externals:
-    - spec: openjdk@1.8.0_302-b08
-      prefix: /usr
+    - spec: openjdk@1.8.0_302-b08 # manually added
+      prefix: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.302.b08-0.el7_9.x86_64
   krb5:
     externals:
     - spec: krb5@1.15.1


### PR DESCRIPTION
OpenJDK was detected with spack, but that prefix path doesn't work.
So I set it to https://github.com/C2SM/spack-c2sm/blob/767e0737a8bfe886cfa40e057eea97ed1a20427b/sysconfigs/tsa/packages.yaml#L111 and it seems to work because I was able to install `ant`.
There's no test that covers this.