### PR TITLE
568 report tests in a table

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,7 @@ pipeline {
                             sh """
                             source env/bin/activate
                             pytest -q --scope \"""" + env.ghprbCommentBody + " serial\" test/system_test.py"
+                            touch serial_test_run
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                             sh """
                             source env/bin/activate
                             pytest -q --scope \"""" + env.ghprbCommentBody + " serial\" test/system_test.py"
-                            touch serial_test_run
+                            touch log/${NODENAME}/system_test/serial_test_run
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ pipeline {
                     stage('System Tests Serial') {
                         steps {
                             sh """
+                            mkdir -p log/${NODENAME}/system_test
                             touch log/${NODENAME}/system_test/serial_test_run
                             source env/bin/activate
                             pytest -q --scope \"""" + env.ghprbCommentBody + " serial\" test/system_test.py"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,9 @@ pipeline {
                     stage('System Tests Serial') {
                         steps {
                             sh """
+                            touch log/${NODENAME}/system_test/serial_test_run
                             source env/bin/activate
                             pytest -q --scope \"""" + env.ghprbCommentBody + " serial\" test/system_test.py"
-                            touch log/${NODENAME}/system_test/serial_test_run
                         }
                     }
                 }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 from .format import time_format, sanitized_filename
 from .machine import machine_name
 from .spack_commands import log_with_spack
-from .github import GitHubRepo, Markdown
+from .github import GitHubRepo, Markdown, HTML
 from .scope import all_machines, all_packages, explicit_scope, package_triggers

--- a/src/github.py
+++ b/src/github.py
@@ -8,14 +8,13 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def add_test_to_text(test, test_col, col, logfiles, text):
-        if test_col:
-            details = [['', 'Test']]
-            for i in range(len(logfiles)):
-                if test in logfiles[i]:
-                    details.append([col[i], logfiles[i]])
-            text = text + HTML.collapsible(test_col + ' ' + test + ' test',
-                                           HTML.table(details))
+    def add_test(test: str, test_col: str, col: list, logfiles: list) -> str:
+        details = [['', 'Test']]
+        for i in range(len(logfiles)):
+            if test in logfiles[i]:
+                details.append([col[i], logfiles[i]])
+        text = HTML.collapsible(test_col + ' ' + test + ' test',
+                                       HTML.table(details))
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:

--- a/src/github.py
+++ b/src/github.py
@@ -29,7 +29,7 @@ class GitHubRepo:
                     test_name = test_name.replace('.log', '')
                     text = text + '<tr><td>' + col[i]
                     text = text + '</td><td>' + test_name + '</td></tr>\n'
-        return(text)
+        return (text)
 
     def comment(self, issue_id: str, text: str) -> None:
         url = f'https://api.github.com/repos/{self.group}/{self.repo}/issues/{issue_id}/comments'
@@ -53,7 +53,8 @@ class GitHubRepo:
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
-        text_new = GitHubRepo.add_test_to_text('integration', int, int_col, details, col, text_new)
+        text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
+                                               details, col, text_new)
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -9,6 +9,7 @@ class GitHubRepo:
         self.auth_token: str = auth_token
 
     def get_color(test, details, col):
+        test_exist = False
         test_col = ':green_circle:'
         for i in range(len(details)):
             if test in details[i][1]:
@@ -52,8 +53,14 @@ class GitHubRepo:
 
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
+        [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
+        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col,
+                                               details, col, text_new)
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
         text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
+                                               details, col, text_new)
+        [sys, sys_col] = GitHubRepo.get_color('system', details, col)
+        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col,
                                                details, col, text_new)
 
         text_new = text_new + '</tbody>\n</table>\n</details>'

--- a/src/github.py
+++ b/src/github.py
@@ -35,7 +35,8 @@ class GitHubRepo:
                 integration = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
                     integration_col = ':red_circle:'
-                elif col[i] == ':yellow_circle:' and not integration_col == ':red_circle:':
+                elif col[
+                        i] == ':yellow_circle:' and not integration_col == ':red_circle:':
                     integration_col = ':yellow_circle:'
 
         if integration:
@@ -44,7 +45,8 @@ class GitHubRepo:
                 if 'integration' in details[i][1]:
                     test_name = details[i][2].replace('_', ' ')
                     test_name = test_name.replace('.log', '')
-                    text_new = text_new + '<tr><td>' + col[i] + '</td><td>'+ test_name + '</td></tr>\n'
+                    text_new = text_new + '<tr><td>' + col[
+                        i] + '</td><td>' + test_name + '</td></tr>\n'
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -14,8 +14,8 @@ class GitHubRepo:
         headers = {'Content-Type': 'application/json'}
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
-
-        requests.post(url, headers=headers, json={'body': text})
+# Add comment to enable merge request
+#        requests.post(url, headers=headers, json={'body': text})
 
 
 class Markdown:

--- a/src/github.py
+++ b/src/github.py
@@ -62,10 +62,11 @@ class Markdown:
             for row in [data[0], ['---' for d in data[0]], *data[1:]])
 
     @staticmethod
-    def header(text: str, level: int=1) -> str:
-        if (level<1) or (level>6):
+    def header(text: str, level: int = 1) -> str:
+        if (level < 1) or (level > 6):
             raise Exception('Invalid header level')
-        return ('#'*level + ' ' +  text + '\n')
+        return ('#' * level + ' ' + text + '\n')
+
 
 class HTML:
 

--- a/src/github.py
+++ b/src/github.py
@@ -35,19 +35,18 @@ class GitHubRepo:
                 integration = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
                     integration_col = ':red_circle:'
-                elif col[
-                        i] == ':yellow_circle:' and not integration_col == ':red_circle:':
+                elif col[i] == ':yellow_circle:' and not integration_col == ':red_circle:':
                     integration_col = ':yellow_circle:'
 
         if integration:
             text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
-                test_name = details[i][2].replace('_', ' ')
-                test_name = test_name.replace('.log', '')
-                text_new = text_new + '<tr><td>' + col[
-                    i] + '</td><td>' + test_name + '</td></tr>\n'
+                if 'integration' in details[i][1]:
+                    test_name = details[i][2].replace('_', ' ')
+                    test_name = test_name.replace('.log', '')
+                    text_new = text_new + '<tr><td>' + col[i] + '</td><td>'+ test_name + '</td></tr>\n'
+
         text_new = text_new + '</tbody>\n</table>\n</details>'
-        print(text_new)
         requests.post(url, headers=headers, json={'body': text_new})
 
 

--- a/src/github.py
+++ b/src/github.py
@@ -22,7 +22,8 @@ class GitHubRepo:
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 
-    def add_test_to_text(test, test_exist, test_col, details, col, logfiles, text):
+    def add_test_to_text(test, test_exist, test_col, details, col, logfiles,
+                         text):
         if test_exist:
             text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
@@ -30,7 +31,8 @@ class GitHubRepo:
                     test_name = details[i][2].replace('_', ' ')
                     test_name = test_name.replace('.log', '')
                     text = text + '<tr><td>' + col[i]
-                    text = text + '</td><td><a href="' + logfiles[i] + '">' + test_name + '</a></td></tr>\n'
+                    text = text + '</td><td><a href="' + logfiles[
+                        i] + '">' + test_name + '</a></td></tr>\n'
             text = text + '</tbody>\n</table>\n</details>'
         return (text)
 
@@ -62,7 +64,8 @@ class GitHubRepo:
                                                col, logfiles, text_new)
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
         text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               details, col, logfiles, text_new)
+                                               details, col, logfiles,
+                                               text_new)
         [sys, sys_col] = GitHubRepo.get_color('system', details, col)
         text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
                                                col, logfiles, text_new)

--- a/src/github.py
+++ b/src/github.py
@@ -14,6 +14,8 @@ class GitHubRepo:
         headers = {'Content-Type': 'application/json'}
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
+
+
 # Add comment to enable merge request
 #        requests.post(url, headers=headers, json={'body': text})
 

--- a/src/github.py
+++ b/src/github.py
@@ -28,9 +28,11 @@ class GitHubRepo:
             for i in range(len(logfiles)):
                 if test in logfiles[i]:
                     details = details + '<tr><td>' + col[i]
-                    details = details + '</td><td>' + logfiles[i] + '</td></tr>\n'
+                    details = details + '</td><td>' + logfiles[
+                        i] + '</td></tr>\n'
             details = details + '</tbody>\n</table>'
-            text = text + HTML.collapsible(test_col + ' ' + test + ' test', details)
+            text = text + HTML.collapsible(test_col + ' ' + test + ' test',
+                                           details)
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:

--- a/src/github.py
+++ b/src/github.py
@@ -8,16 +8,6 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def get_test_result(test, logfiles, col):
-        if any(test in l for l in logfiles):
-            if all(c == ':green_circle:' for c in col):
-                test_col = ':green_circle:'
-            else:
-                test_col = ':red_circle:'
-        else:
-            test_col = None
-        return (test_col)
-
     def add_test_to_text(test, test_col, col, logfiles, text):
         if test_col:
             details = [['', 'Test']]

--- a/src/github.py
+++ b/src/github.py
@@ -106,6 +106,33 @@ class Markdown:
             ' | '.join(str(cell) for cell in row)
             for row in [data[0], ['---' for d in data[0]], *data[1:]])
 
+
+class HTML:
+
+    @staticmethod
+    def link(text: str, url: str) -> str:
+        return f'<a href="{url}">{text}</a>'
+
+    @staticmethod
+    def table(data) -> str:        
+        table = '<table>'
+        table += '<thead>'
+        table += '<tr>'
+        for cell in data[0]:
+            print(cell)
+            table += f'<th>{cell}</th>'
+        table += '</tr>'
+        table += '</thead>'
+        table += '<tbody>'
+        for row in data[1:]:
+            table += '<tr>'
+            for cell in row:
+                table += f'<td>{cell}</td>'
+            table += '</tr>'
+        table += '</tbody>'
+        table += '</table>'
+        return table
+
     @staticmethod
     def collapsible(summary: str, details: str) -> str:
         return f'<details><summary>{summary}</summary>{details}</details>'

--- a/src/github.py
+++ b/src/github.py
@@ -8,15 +8,6 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def add_test(test: str, test_col: str, col: list, logfiles: list) -> str:
-        details = [['', 'Test']]
-        for l, c in zip(logfiles, col):
-            if test in l:
-                details.append([c, l])
-        text = HTML.collapsible(test_col + ' ' + test + ' test',
-                                HTML.table(details))
-        return (text)
-
     def comment(self, issue_id: str, text: str) -> None:
         url = f'https://api.github.com/repos/{self.group}/{self.repo}/issues/{issue_id}/comments'
 
@@ -55,10 +46,9 @@ class Markdown:
         return f'```{language}\n{code}\n```'
 
     @staticmethod
-    def table(data) -> str:
-        return '\n'.join(
-            ' | '.join(str(cell) for cell in row)
-            for row in [data[0], ['---' for d in data[0]], *data[1:]])
+    def table(head, body) -> str:
+        data = [head, ['---'] * len(head)] + body
+        return '\n'.join(' | '.join(row) for row in data)
 
     @staticmethod
     def header(text: str, level: int = 1) -> str:
@@ -74,16 +64,16 @@ class HTML:
         return f'<a href="{url}">{text}</a>'
 
     @staticmethod
-    def table(data) -> str:
+    def table(head, body) -> str:
         table = '<table>'
         table += '<thead>'
         table += '<tr>'
-        for cell in data[0]:
+        for cell in head:
             table += f'<th>{cell}</th>'
         table += '</tr>'
         table += '</thead>'
         table += '<tbody>'
-        for row in data[1:]:
+        for row in body:
             table += '<tr>'
             for cell in row:
                 table += f'<td>{cell}</td>'

--- a/src/github.py
+++ b/src/github.py
@@ -43,33 +43,6 @@ class GitHubRepo:
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
 
-        f = filter(None, text.split('\n'))
-        text_lines = list(f)
-
-        details = []
-        logfiles = []
-        col = []
-        for item in text_lines:
-            details.append(item[item.find('[') + 1:item.rfind(']')])
-            logfiles.append(item[item.find('(') + 1:item.rfind(')')])
-            col.append(item.split()[0])
-
-        for i, item in enumerate(details):
-            details[i] = item.split('/')
-
-        text_new = '### ' + details[0][0] + '\n'
-
-        [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
-        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, details,
-                                               col, logfiles, text_new)
-        [int, int_col] = GitHubRepo.get_color('integration', details, col)
-        text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               details, col, logfiles,
-                                               text_new)
-        [sys, sys_col] = GitHubRepo.get_color('system', details, col)
-        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
-                                               col, logfiles, text_new)
-
         requests.post(url, headers=headers, json={'body': text_new})
 
 

--- a/src/github.py
+++ b/src/github.py
@@ -114,7 +114,7 @@ class HTML:
         return f'<a href="{url}">{text}</a>'
 
     @staticmethod
-    def table(data) -> str:        
+    def table(data) -> str:
         table = '<table>'
         table += '<thead>'
         table += '<tr>'

--- a/src/github.py
+++ b/src/github.py
@@ -44,7 +44,8 @@ class GitHubRepo:
             for i in range(len(details)):
                 test_name = details[i][2].replace('_', ' ')
                 test_name = test_name.replace('.log', '')
-                text_new = text_new + '<tr><td>' + col[i] + '</td><td>'+ test_name + '</td></tr>\n'
+                text_new = text_new + '<tr><td>' + col[
+                    i] + '</td><td>' + test_name + '</td></tr>\n'
         text_new = text_new + '</tbody>\n</table>\n</details>'
         print(text_new)
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -61,6 +61,11 @@ class Markdown:
             ' | '.join(str(cell) for cell in row)
             for row in [data[0], ['---' for d in data[0]], *data[1:]])
 
+    @staticmethod
+    def header(text: str, level: int=1) -> str:
+        if (level<1) or (level>6):
+            raise Exception('Invalid header level')
+        return ('#'*level + ' ' +  text + '\n')
 
 class HTML:
 

--- a/src/github.py
+++ b/src/github.py
@@ -24,12 +24,13 @@ class GitHubRepo:
 
     def add_test_to_text(test, test_exist, test_col, col, logfiles, text):
         if test_exist:
-            text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
+            details = '<table><tbody><tr><td>'
             for i in range(len(logfiles)):
                 if test in logfiles[i]:
-                    text = text + '<tr><td>' + col[i]
-                    text = text + '</td><td>' + logfiles[i] + '</td></tr>\n'
-            text = text + '</tbody>\n</table>\n</details>'
+                    details = details + '<tr><td>' + col[i]
+                    details = details + '</td><td>' + logfiles[i] + '</td></tr>\n'
+            details = details + '</tbody>\n</table>'
+            text = text + HTML.collapsible(test_col + ' ' + test + ' test', details)
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:

--- a/src/github.py
+++ b/src/github.py
@@ -24,13 +24,14 @@ class GitHubRepo:
 
     def add_test_to_text(test, test_exist, test_col, details, col, text):
         if test_exist:
-            text = text + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
+            text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
                 if test in details[i][1]:
                     test_name = details[i][2].replace('_', ' ')
                     test_name = test_name.replace('.log', '')
                     text = text + '<tr><td>' + col[i]
                     text = text + '</td><td>' + test_name + '</td></tr>\n'
+            text = text + '</tbody>\n</table>\n</details>'
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:
@@ -52,7 +53,7 @@ class GitHubRepo:
         for i, item in enumerate(details):
             details[i] = item.split('/')
 
-        text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
+        text_new = '### ' + details[0][0] + '\n'
 
         [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
         text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, details,
@@ -64,7 +65,6 @@ class GitHubRepo:
         text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
                                                col, text_new)
 
-        text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})
 
 

--- a/src/github.py
+++ b/src/github.py
@@ -14,7 +14,8 @@ class GitHubRepo:
         for i in range(len(details)):
             if test in details[i][1]:
                 test_exist = True
-                if col[i] == ':red_circle:' or col[i] == ':lock:' or col[i] == ':wastebasket:' or col[i] == ':hourglass:':
+                if col[i] == ':red_circle:' or col[i] == ':lock:' or col[
+                        i] == ':wastebasket:' or col[i] == ':hourglass:':
                     test_col = ':red_circle:'
                 elif col[
                         i] == ':yellow_circle:' and not test_col == ':red_circle:':

--- a/src/github.py
+++ b/src/github.py
@@ -17,8 +17,8 @@ class GitHubRepo:
 
 
 # Add comment to enable merge request
-#        requests.post(url, headers=headers, json={'body': text})
-
+        requests.post(url, headers=headers, json={'body': text})
+#        print(text)
 
 class Markdown:
     # Source: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet

--- a/src/github.py
+++ b/src/github.py
@@ -35,7 +35,8 @@ class GitHubRepo:
                 int = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
                     int_col = ':red_circle:'
-                elif col[i] == ':yellow_circle:' and not int_col == ':red_circle:':
+                elif col[
+                        i] == ':yellow_circle:' and not int_col == ':red_circle:':
                     int_col = ':yellow_circle:'
 
         if int:
@@ -49,6 +50,7 @@ class GitHubRepo:
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})
+
 
 class Markdown:
     # Source: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet

--- a/src/github.py
+++ b/src/github.py
@@ -54,14 +54,14 @@ class GitHubRepo:
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
         [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
-        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col,
-                                               details, col, text_new)
+        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, details,
+                                               col, text_new)
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
         text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
                                                details, col, text_new)
         [sys, sys_col] = GitHubRepo.get_color('system', details, col)
-        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col,
-                                               details, col, text_new)
+        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
+                                               col, text_new)
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -8,7 +8,7 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def get_color(test, logfiles, col):
+    def get_test_result(test, logfiles, col):
         test_exist = False
         test_col = ':green_circle:'
         for i in range(len(logfiles)):

--- a/src/github.py
+++ b/src/github.py
@@ -15,11 +15,38 @@ class GitHubRepo:
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
 
-# Add comment to enable merge request
-        requests.post(url, headers=headers, json={'body': text})
+        f = filter(None, text.split('\n'))
+        text_lines = list(f)
 
+        details = []
+        col = []
+        for item in text_lines:
+            details.append(item[item.find('[')+1:item.rfind(']')])
+            col.append(item.split()[0])
 
-#        print(text)
+        for i, item in enumerate(details): details[i] = item.split('/')
+
+        text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
+
+        integration_col = ':green_circle:'
+        for i in range(len(details)):
+            if 'integration' in details[i][1]:
+                integration = True
+                if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
+                    integration_col = ':red_circle:'
+                elif col[i] == ':yellow_circle:' and not integration_col == ':red_circle:':
+                    integration_col = ':yellow_circle:'
+
+        if integration:
+            text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n<tr>\n'
+            for i in range(len(details)):
+                test_name = details[i][2].replace('_',' ')
+                test_name = test_name.replace('.log','')
+                text_new = text_new + '<td>' +  col[i] + test_name + '</td>\n'
+            text_new = text_new + '</tr>\n'
+        text_new = text_new + '</tbody>\n</table>\n</details>'
+        print(text_new)
+        requests.post(url, headers=headers, json={'body': text_new})
 
 
 class Markdown:

--- a/src/github.py
+++ b/src/github.py
@@ -10,9 +10,9 @@ class GitHubRepo:
 
     def add_test(test: str, test_col: str, col: list, logfiles: list) -> str:
         details = [['', 'Test']]
-        for i in range(len(logfiles)):
-            if test in logfiles[i]:
-                details.append([col[i], logfiles[i]])
+        for l,c in zip(logfiles,col):
+            if test in l:
+                details.append([c, l])
         text = HTML.collapsible(test_col + ' ' + test + ' test',
                                 HTML.table(details))
         return (text)

--- a/src/github.py
+++ b/src/github.py
@@ -20,6 +20,17 @@ class GitHubRepo:
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 
+    def add_test_to_text(test, test_exist, test_col, details, col, text):
+        if test_exist:
+            text = text + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
+            for i in range(len(details)):
+                if test in details[i][1]:
+                    test_name = details[i][2].replace('_', ' ')
+                    test_name = test_name.replace('.log', '')
+                    text = text + '<tr><td>' + col[i]
+                    text = text + '</td><td>' + test_name + '</td></tr>\n'
+        return(text)
+
     def comment(self, issue_id: str, text: str) -> None:
         url = f'https://api.github.com/repos/{self.group}/{self.repo}/issues/{issue_id}/comments'
 
@@ -42,15 +53,7 @@ class GitHubRepo:
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
-
-        if int:
-            text_new = text_new + int_col + ' Integration test</summary>\n<table>\n<tbody>\n'
-            for i in range(len(details)):
-                if 'integration' in details[i][1]:
-                    test_name = details[i][2].replace('_', ' ')
-                    test_name = test_name.replace('.log', '')
-                    text_new = text_new + '<tr><td>' + col[i]
-                    text_new = text_new + '</td><td>' + test_name + '</td></tr>\n'
+        text_new = GitHubRepo.add_test_to_text('integration', int, int_col, details, col, text_new)
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -10,7 +10,7 @@ class GitHubRepo:
 
     def add_test(test: str, test_col: str, col: list, logfiles: list) -> str:
         details = [['', 'Test']]
-        for l,c in zip(logfiles,col):
+        for l, c in zip(logfiles, col):
             if test in l:
                 details.append([c, l])
         text = HTML.collapsible(test_col + ' ' + test + ' test',

--- a/src/github.py
+++ b/src/github.py
@@ -14,7 +14,7 @@ class GitHubRepo:
         for i in range(len(details)):
             if test in details[i][1]:
                 test_exist = True
-                if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
+                if col[i] == ':red_circle:' or col[i] == ':lock:' or col[i] == ':wastebasket:' or col[i] == ':hourglass:':
                     test_col = ':red_circle:'
                 elif col[
                         i] == ':yellow_circle:' and not test_col == ':red_circle:':

--- a/src/github.py
+++ b/src/github.py
@@ -22,7 +22,7 @@ class GitHubRepo:
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 
-    def add_test_to_text(test, test_exist, test_col, details, col, text):
+    def add_test_to_text(test, test_exist, test_col, details, col, logfiles, text):
         if test_exist:
             text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
@@ -30,7 +30,7 @@ class GitHubRepo:
                     test_name = details[i][2].replace('_', ' ')
                     test_name = test_name.replace('.log', '')
                     text = text + '<tr><td>' + col[i]
-                    text = text + '</td><td>' + test_name + '</td></tr>\n'
+                    text = text + '</td><td><a href="' + logfiles[i] + '">' + test_name + '</a></td></tr>\n'
             text = text + '</tbody>\n</table>\n</details>'
         return (text)
 
@@ -45,9 +45,11 @@ class GitHubRepo:
         text_lines = list(f)
 
         details = []
+        logfiles = []
         col = []
         for item in text_lines:
             details.append(item[item.find('[') + 1:item.rfind(']')])
+            logfiles.append(item[item.find('(') + 1:item.rfind(')')])
             col.append(item.split()[0])
 
         for i, item in enumerate(details):
@@ -57,13 +59,13 @@ class GitHubRepo:
 
         [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
         text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, details,
-                                               col, text_new)
+                                               col, logfiles, text_new)
         [int, int_col] = GitHubRepo.get_color('integration', details, col)
         text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               details, col, text_new)
+                                               details, col, logfiles, text_new)
         [sys, sys_col] = GitHubRepo.get_color('system', details, col)
         text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
-                                               col, text_new)
+                                               col, logfiles, text_new)
 
         requests.post(url, headers=headers, json={'body': text_new})
 

--- a/src/github.py
+++ b/src/github.py
@@ -24,15 +24,12 @@ class GitHubRepo:
 
     def add_test_to_text(test, test_exist, test_col, col, logfiles, text):
         if test_exist:
-            details = '<table><tbody><tr><td>'
+            details = [['','Test']]
             for i in range(len(logfiles)):
                 if test in logfiles[i]:
-                    details = details + '<tr><td>' + col[i]
-                    details = details + '</td><td>' + logfiles[
-                        i] + '</td></tr>\n'
-            details = details + '</tbody>\n</table>'
+                    details.append([col[i], logfiles[i]])
             text = text + HTML.collapsible(test_col + ' ' + test + ' test',
-                                           details)
+                                           HTML.table(details))
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:

--- a/src/github.py
+++ b/src/github.py
@@ -9,19 +9,17 @@ class GitHubRepo:
         self.auth_token: str = auth_token
 
     def get_test_result(test, logfiles, col):
-        test_exist = False
-        test_col = ':green_circle:'
-        for c, logfile in zip(col, logfiles):
-            if test in logfile:
-                test_exist = True
-                if c == ':red_circle:' or c == ':lock:' or c == ':wastebasket:' or c == ':hourglass:':
-                    test_col = ':red_circle:'
-                elif c == ':yellow_circle:' and not test_col == ':red_circle:':
-                    test_col = ':yellow_circle:'
-        return (test_exist, test_col)
+        if any(test in l for l in logfiles):
+            if all(c == ':green_circle:' for c in col):
+                test_col = ':green_circle:'
+            else:
+                test_col = ':red_circle:'
+        else:
+            test_col = None
+        return (test_col)
 
-    def add_test_to_text(test, test_exist, test_col, col, logfiles, text):
-        if test_exist:
+    def add_test_to_text(test, test_col, col, logfiles, text):
+        if test_col:
             details = [['', 'Test']]
             for i in range(len(logfiles)):
                 if test in logfiles[i]:

--- a/src/github.py
+++ b/src/github.py
@@ -40,12 +40,11 @@ class GitHubRepo:
                     integration_col = ':yellow_circle:'
 
         if integration:
-            text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n<tr>\n'
+            text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
                 test_name = details[i][2].replace('_', ' ')
                 test_name = test_name.replace('.log', '')
-                text_new = text_new + '<td>' + col[i] + test_name + '</td>\n'
-            text_new = text_new + '</tr>\n'
+                text_new = text_new + '<tr><td>' + col[i] + '</td><td>'+ test_name + '</td></tr>\n'
         text_new = text_new + '</tbody>\n</table>\n</details>'
         print(text_new)
         requests.post(url, headers=headers, json={'body': text_new})

--- a/src/github.py
+++ b/src/github.py
@@ -14,7 +14,7 @@ class GitHubRepo:
             if test in logfiles[i]:
                 details.append([col[i], logfiles[i]])
         text = HTML.collapsible(test_col + ' ' + test + ' test',
-                                       HTML.table(details))
+                                HTML.table(details))
         return (text)
 
     def comment(self, issue_id: str, text: str) -> None:

--- a/src/github.py
+++ b/src/github.py
@@ -88,7 +88,6 @@ class HTML:
         table += '<thead>'
         table += '<tr>'
         for cell in data[0]:
-            print(cell)
             table += f'<th>{cell}</th>'
         table += '</tr>'
         table += '</thead>'

--- a/src/github.py
+++ b/src/github.py
@@ -8,16 +8,17 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def get_color(test,details,col):
+    def get_color(test, details, col):
         test_col = ':green_circle:'
         for i in range(len(details)):
             if test in details[i][1]:
                 test_exist = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
                     test_col = ':red_circle:'
-                elif col[i] == ':yellow_circle:' and not test_col == ':red_circle:':
+                elif col[
+                        i] == ':yellow_circle:' and not test_col == ':red_circle:':
                     test_col = ':yellow_circle:'
-        return(test_exist,test_col)
+        return (test_exist, test_col)
 
     def comment(self, issue_id: str, text: str) -> None:
         url = f'https://api.github.com/repos/{self.group}/{self.repo}/issues/{issue_id}/comments'
@@ -40,7 +41,7 @@ class GitHubRepo:
 
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
-        [int, int_col] = GitHubRepo.get_color('integration',details,col)
+        [int, int_col] = GitHubRepo.get_color('integration', details, col)
 
         if int:
             text_new = text_new + int_col + ' Integration test</summary>\n<table>\n<tbody>\n'

--- a/src/github.py
+++ b/src/github.py
@@ -29,28 +29,26 @@ class GitHubRepo:
 
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
-        integration_col = ':green_circle:'
+        int_col = ':green_circle:'
         for i in range(len(details)):
             if 'integration' in details[i][1]:
-                integration = True
+                int = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
-                    integration_col = ':red_circle:'
-                elif col[
-                        i] == ':yellow_circle:' and not integration_col == ':red_circle:':
-                    integration_col = ':yellow_circle:'
+                    int_col = ':red_circle:'
+                elif col[i] == ':yellow_circle:' and not int_col == ':red_circle:':
+                    int_col = ':yellow_circle:'
 
-        if integration:
-            text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n'
+        if int:
+            text_new = text_new + int_col + ' Integration test</summary>\n<table>\n<tbody>\n'
             for i in range(len(details)):
                 if 'integration' in details[i][1]:
                     test_name = details[i][2].replace('_', ' ')
                     test_name = test_name.replace('.log', '')
-                    text_new = text_new + '<tr><td>' + col[
-                        i] + '</td><td>' + test_name + '</td></tr>\n'
+                    text_new = text_new + '<tr><td>' + col[i]
+                    text_new = text_new + '</td><td>' + test_name + '</td></tr>\n'
 
         text_new = text_new + '</tbody>\n</table>\n</details>'
         requests.post(url, headers=headers, json={'body': text_new})
-
 
 class Markdown:
     # Source: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet

--- a/src/github.py
+++ b/src/github.py
@@ -8,6 +8,17 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
+    def get_color(test,details,col):
+        test_col = ':green_circle:'
+        for i in range(len(details)):
+            if test in details[i][1]:
+                test_exist = True
+                if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
+                    test_col = ':red_circle:'
+                elif col[i] == ':yellow_circle:' and not test_col == ':red_circle:':
+                    test_col = ':yellow_circle:'
+        return(test_exist,test_col)
+
     def comment(self, issue_id: str, text: str) -> None:
         url = f'https://api.github.com/repos/{self.group}/{self.repo}/issues/{issue_id}/comments'
 
@@ -29,15 +40,7 @@ class GitHubRepo:
 
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
-        int_col = ':green_circle:'
-        for i in range(len(details)):
-            if 'integration' in details[i][1]:
-                int = True
-                if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
-                    int_col = ':red_circle:'
-                elif col[
-                        i] == ':yellow_circle:' and not int_col == ':red_circle:':
-                    int_col = ':yellow_circle:'
+        [int, int_col] = GitHubRepo.get_color('integration',details,col)
 
         if int:
             text_new = text_new + int_col + ' Integration test</summary>\n<table>\n<tbody>\n'

--- a/src/github.py
+++ b/src/github.py
@@ -15,10 +15,12 @@ class GitHubRepo:
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
 
-
 # Add comment to enable merge request
         requests.post(url, headers=headers, json={'body': text})
+
+
 #        print(text)
+
 
 class Markdown:
     # Source: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet

--- a/src/github.py
+++ b/src/github.py
@@ -11,14 +11,12 @@ class GitHubRepo:
     def get_test_result(test, logfiles, col):
         test_exist = False
         test_col = ':green_circle:'
-        for i in range(len(logfiles)):
-            if test in logfiles[i]:
+        for c, logfile in zip(col, logfiles):
+            if test in logfile:
                 test_exist = True
-                if col[i] == ':red_circle:' or col[i] == ':lock:' or col[
-                        i] == ':wastebasket:' or col[i] == ':hourglass:':
+                if c == ':red_circle:' or c == ':lock:' or c == ':wastebasket:' or c == ':hourglass:':
                     test_col = ':red_circle:'
-                elif col[
-                        i] == ':yellow_circle:' and not test_col == ':red_circle:':
+                elif c == ':yellow_circle:' and not test_col == ':red_circle:':
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 

--- a/src/github.py
+++ b/src/github.py
@@ -21,10 +21,11 @@ class GitHubRepo:
         details = []
         col = []
         for item in text_lines:
-            details.append(item[item.find('[')+1:item.rfind(']')])
+            details.append(item[item.find('[') + 1:item.rfind(']')])
             col.append(item.split()[0])
 
-        for i, item in enumerate(details): details[i] = item.split('/')
+        for i, item in enumerate(details):
+            details[i] = item.split('/')
 
         text_new = '### ' + details[0][0] + '\n' + '<details>\n<summary>'
 
@@ -34,15 +35,16 @@ class GitHubRepo:
                 integration = True
                 if col[i] == ':red_circle:' or ':lock:' or ':wastebasket:' or ':hourglass:':
                     integration_col = ':red_circle:'
-                elif col[i] == ':yellow_circle:' and not integration_col == ':red_circle:':
+                elif col[
+                        i] == ':yellow_circle:' and not integration_col == ':red_circle:':
                     integration_col = ':yellow_circle:'
 
         if integration:
             text_new = text_new + integration_col + ' Integration test</summary>\n<table>\n<tbody>\n<tr>\n'
             for i in range(len(details)):
-                test_name = details[i][2].replace('_',' ')
-                test_name = test_name.replace('.log','')
-                text_new = text_new + '<td>' +  col[i] + test_name + '</td>\n'
+                test_name = details[i][2].replace('_', ' ')
+                test_name = test_name.replace('.log', '')
+                text_new = text_new + '<td>' + col[i] + test_name + '</td>\n'
             text_new = text_new + '</tr>\n'
         text_new = text_new + '</tbody>\n</table>\n</details>'
         print(text_new)

--- a/src/github.py
+++ b/src/github.py
@@ -24,7 +24,7 @@ class GitHubRepo:
 
     def add_test_to_text(test, test_exist, test_col, col, logfiles, text):
         if test_exist:
-            details = [['','Test']]
+            details = [['', 'Test']]
             for i in range(len(logfiles)):
                 if test in logfiles[i]:
                     details.append([col[i], logfiles[i]])

--- a/src/github.py
+++ b/src/github.py
@@ -22,8 +22,7 @@ class GitHubRepo:
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 
-    def add_test_to_text(test, test_exist, test_col, col, logfiles,
-                         text):
+    def add_test_to_text(test, test_exist, test_col, col, logfiles, text):
         if test_exist:
             text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
             for i in range(len(logfiles)):

--- a/src/github.py
+++ b/src/github.py
@@ -8,11 +8,11 @@ class GitHubRepo:
         self.repo: str = repo
         self.auth_token: str = auth_token
 
-    def get_color(test, details, col):
+    def get_color(test, logfiles, col):
         test_exist = False
         test_col = ':green_circle:'
-        for i in range(len(details)):
-            if test in details[i][1]:
+        for i in range(len(logfiles)):
+            if test in logfiles[i]:
                 test_exist = True
                 if col[i] == ':red_circle:' or col[i] == ':lock:' or col[
                         i] == ':wastebasket:' or col[i] == ':hourglass:':
@@ -22,17 +22,14 @@ class GitHubRepo:
                     test_col = ':yellow_circle:'
         return (test_exist, test_col)
 
-    def add_test_to_text(test, test_exist, test_col, details, col, logfiles,
+    def add_test_to_text(test, test_exist, test_col, col, logfiles,
                          text):
         if test_exist:
             text = text + '<details>\n<summary>' + test_col + ' ' + test + ' test</summary>\n<table>\n<tbody>\n'
-            for i in range(len(details)):
-                if test in details[i][1]:
-                    test_name = details[i][2].replace('_', ' ')
-                    test_name = test_name.replace('.log', '')
+            for i in range(len(logfiles)):
+                if test in logfiles[i]:
                     text = text + '<tr><td>' + col[i]
-                    text = text + '</td><td><a href="' + logfiles[
-                        i] + '">' + test_name + '</a></td></tr>\n'
+                    text = text + '</td><td>' + logfiles[i] + '</td></tr>\n'
             text = text + '</tbody>\n</table>\n</details>'
         return (text)
 
@@ -43,7 +40,7 @@ class GitHubRepo:
         if self.auth_token is not None:
             headers['Authorization'] = 'token ' + self.auth_token
 
-        requests.post(url, headers=headers, json={'body': text_new})
+        requests.post(url, headers=headers, json={'body': text})
 
 
 class Markdown:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -14,7 +14,7 @@ class ResultList:
         self.text = ''
 
     def append(self, status: str, test: str, comment: str = '') -> None:
-        name = test[test.rfind('/')+1:test.rfind('.log')]
+        name = test[test.rfind('/') + 1:test.rfind('.log')]
         name = name.replace('_', ' ')
         link = HTML.link(name, self.artifact_path + test)
         self.text += f'{status} {link} {comment}\n'
@@ -73,21 +73,20 @@ if __name__ == "__main__":
         logfiles = []
         col = []
         for item in text_lines:
-            logfiles.append(item[item.find('<a'):item.rfind('a>')+2])
+            logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
         text_new = f'###  {machine_name()}\n'
 
         [unit, unit_col] = GitHubRepo.get_color('unit', logfiles, col)
-        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col,
-                                               col, logfiles, text_new)
+        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
+                                               logfiles, text_new)
         [int, int_col] = GitHubRepo.get_color('integration', logfiles, col)
         text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               col, logfiles,
-                                               text_new)
-        [sys, sys_col] = GitHubRepo.get_color('system', logfiles, col)
-        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col,
                                                col, logfiles, text_new)
+        [sys, sys_col] = GitHubRepo.get_color('system', logfiles, col)
+        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, col,
+                                               logfiles, text_new)
         comment = text_new
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -15,16 +15,15 @@ class ResultList:
 
     def append(self, status: str, test: str, comment: str = '') -> None:
         name = test[test.rfind('/') + 1:test.rfind('.log')]
-        name = name.replace('_', ' ')
         link = HTML.link(name, self.artifact_path + test)
         self.text += f'{status} {link} {comment}\n'
 
     def get_test_result(test, logfiles, col):
         if any(test in l for l in logfiles):
-            if all(c == ':green_circle:' for c in col):
-                test_col = ':green_circle:'
-            else:
-                test_col = ':red_circle:'
+            test_col = ':green_circle:'
+            for l,c in zip(logfiles,col):
+                if test in l and c != ':green_circle:':
+                    test_col = ':red_circle:'
         else:
             test_col = None
         return (test_col)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -21,7 +21,7 @@ class ResultList:
     def get_test_result(test, logfiles, col):
         if any(test in l for l in logfiles):
             test_col = ':green_circle:'
-            for l,c in zip(logfiles,col):
+            for l, c in zip(logfiles, col):
                 if test in l and c != ':green_circle:':
                     test_col = ':red_circle:'
         else:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     if summary.text == '':
         comment = f'No tests ran on {machine_name()}.'
     else:
-        summary_rows= list(filter(None, summary.text.split('\n')))
+        summary_rows = list(filter(None, summary.text.split('\n')))
         logfiles = []
         col = []
         for item in summary_rows:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
             logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
-        comment = Markdown.header(f'{machine_name()}', 3)
+        comment = Markdown.header(machine_name(), level=3)
 
         unit_col = ResultList.get_test_result('unit', logfiles, col)
         if unit_col:

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -1,30 +1,24 @@
 import os
 import argparse
 import glob
+from pathlib import Path
 from github import GitHubRepo, Markdown, HTML
 from machine import machine_name
 
 
-class ResultList:
+class ResultTable:
 
     def __init__(self, artifact_path: str) -> None:
         self.artifact_path = artifact_path
-        self.text = ''
+        self.head = ['', 'Test']
+        self.body = []
 
-    def append(self, status: str, test: str, comment: str = '') -> None:
-        name = test[test.rfind('/') + 1:test.rfind('.log')]
-        link = HTML.link(name, self.artifact_path + test)
-        self.text += f'{status} {link} {comment}\n'
+    def append(self, status: str, log_file: str, comment: str = '') -> None:
+        link = HTML.link(Path(log_file).stem, self.artifact_path + log_file)
+        self.body.append([status, f'{link} {comment}'])
 
-    def get_test_result(test, logfiles, col):
-        if any(test in l for l in logfiles):
-            test_col = ':green_circle:'
-            for l, c in zip(logfiles, col):
-                if test in l and c != ':green_circle:':
-                    test_col = ':red_circle:'
-        else:
-            test_col = None
-        return (test_col)
+    def __str__(self) -> str:
+        return HTML.table(self.head, self.body)
 
 
 if __name__ == "__main__":
@@ -37,67 +31,59 @@ if __name__ == "__main__":
     repo = GitHubRepo(group='c2sm',
                       repo='spack-c2sm',
                       auth_token=args.auth_token)
-    summary = ResultList(
-        f'https://jenkins-mch.cscs.ch/job/Spack/job/spack_PR/{args.build_id}/artifact/log/'
+    table = ResultTable(
+        f'https://jenkins-mch.cscs.ch/job/Spack/job/spack_PR/{args.build_id}/artifact/'
     )
 
-    # Trigger phrases that cause a test to get a yellow circle
-    yellow_triggers = [
-        'timed out after 5 seconds',
+    # Trigger phrases that cause a test to get a special icon and comment.
+    # List[(trigger, icon, comment)]
+    triggers = [
+        ('AssertionError exception when releasing read lock', ':lock:',
+         'spack locking problem'),
+        ('Timed out waiting for a write lock', ':lock:',
+         'spack write lock problem'),
+        ('Timed out waiting for a read lock', ':lock:',
+         'spack read lock problem'),
+        ('gzip: stdin: decompression OK, trailing garbage ignored',
+         ':wastebasket:', 'spack cached archive problem'),
+        ('DUE TO TIME LIMIT', ':hourglass:', 'slurm time limit'),
+        ('timed out after 5 seconds', ':yellow_circle:',
+         'timed out after 5 seconds'),
     ]
 
-    for file_name in sorted(glob.glob('log/**/*.log', recursive=True)):
-        test_name = file_name.lstrip('log/')
-        with open(file_name, 'r') as file:
-            content = file.read()
-            if content.endswith('OK\n'):
-                summary.append(':green_circle:', test_name)
-            elif 'AssertionError exception when releasing read lock' in content:
-                summary.append(':lock:', test_name, 'spack locking problem')
-            elif 'Timed out waiting for a write lock' in content:
-                summary.append(':lock:', test_name, 'spack write lock problem')
-            elif 'Timed out waiting for a read lock' in content:
-                summary.append(':lock:', test_name, 'spack read lock problem')
-            elif 'gzip: stdin: decompression OK, trailing garbage ignored' in content:
-                summary.append(':wastebasket:', test_name,
-                               'spack cached archive problem')
-            elif 'DUE TO TIME LIMIT' in content:
-                summary.append(':hourglass:', test_name, 'slurm time limit')
-            else:
-                for trigger in yellow_triggers:
-                    if trigger in content:
-                        summary.append(':yellow_circle:', test_name, trigger)
-                        break
+    comment = Markdown.header(machine_name(), level=3)
+    any_tests_ran_on_machine = False
+    for test_type in ['unit', 'integration', 'system']:
+        all_tests_of_type_passed = True
+        any_tests_of_type = False
+        for file_name in sorted(
+                glob.glob(f'log/{machine_name()}/{test_type}_test/*.log')):
+            any_tests_ran_on_machine = True
+            any_tests_of_type = True
+            with open(file_name, 'r') as file:
+                content = file.read()
+                if content.endswith('OK\n'):
+                    table.append(':green_circle:', file_name)
                 else:
-                    summary.append(':red_circle:', test_name)
+                    all_tests_of_type_passed = False
+                    for trigger, icon, comment in triggers:
+                        if trigger in content:
+                            table.append(icon, file_name, comment)
+                            break
+                    else:
+                        table.append(':red_circle:', file_name)
 
-    if summary.text == '':
-        comment = f'No tests ran on {machine_name()}.'
-    else:
-        summary_rows = list(filter(None, summary.text.split('\n')))
-        logfiles = []
-        col = []
-        for item in summary_rows:
-            logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
-            col.append(item.split()[0])
+        if any_tests_of_type:
+            if all_tests_of_type_passed:
+                icon = ':green_circle:'
+            else:
+                icon = ':red_circle:'
+            comment += HTML.collapsible(f'{icon} {test_type} test', table)
 
-        comment = Markdown.header(machine_name(), level=3)
+        if test_type == 'system' and not os.path.isfile(f'log/{machine_name()}/system_test/serial_test_run'):
+                comment += '\n\n**WARNING**: Serial tests did not run for system tests'
 
-        unit_col = ResultList.get_test_result('unit', logfiles, col)
-        if unit_col:
-            comment = comment + GitHubRepo.add_test('unit', unit_col, col,
-                                                    logfiles)
-        int_col = ResultList.get_test_result('integration', logfiles, col)
-        if int_col:
-            comment = comment + GitHubRepo.add_test('integration', int_col,
-                                                    col, logfiles)
-        sys_col = ResultList.get_test_result('system', logfiles, col)
-        if sys_col:
-            comment = comment + GitHubRepo.add_test('system', sys_col, col,
-                                                    logfiles)
-            path_to_sys = f'log/{machine_name()}/system_test/'
-            if not os.path.isfile(os.path.join(path_to_sys,
-                                               'serial_test_run')):
-                comment = comment + '\n \n **WARNING**: Serial tests did not run for system tests'
+    if not any_tests_ran_on_machine:
+        comment += f'No tests executed.'
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
             logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
-        comment = f'###  {machine_name()}\n'
+        comment = Markdown.header(f'{machine_name()}',3)
         unit_col = ResultList.get_test_result('unit', logfiles, col)
         comment = GitHubRepo.add_test_to_text('unit', unit_col, col, logfiles,
                                               comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -97,5 +97,8 @@ if __name__ == "__main__":
         if sys_col:
             comment = comment + GitHubRepo.add_test('system', sys_col, col,
                                                     logfiles)
+            path_to_sys = f'https://jenkins-mch.cscs.ch/job/Spack/job/spack_PR/{args.build_id}/artifact/log/{machine_name()}/system_test/'
+            if not os.path.isfile(os.path.join(path_to_sys, 'serial_test_run')):
+                comment = comment + '\n \n **WARNING**: Serial tests did not run for system tests'
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -80,12 +80,13 @@ if __name__ == "__main__":
 
         [unit, unit_col] = GitHubRepo.get_test_result('unit', logfiles, col)
         comment = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
-                                               logfiles, comment)
-        [int, int_col] = GitHubRepo.get_test_result('integration', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               col, logfiles, comment)
+                                              logfiles, comment)
+        [int, int_col] = GitHubRepo.get_test_result('integration', logfiles,
+                                                    col)
+        comment = GitHubRepo.add_test_to_text('integration', int, int_col, col,
+                                              logfiles, comment)
         [sys, sys_col] = GitHubRepo.get_test_result('system', logfiles, col)
         comment = GitHubRepo.add_test_to_text('system', sys, sys_col, col,
-                                               logfiles, comment)
+                                              logfiles, comment)
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -75,15 +75,15 @@ if __name__ == "__main__":
             col.append(item.split()[0])
 
         comment = f'###  {machine_name()}\n'
-        [unit, unit_col] = GitHubRepo.get_test_result('unit', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
+        unit_col = GitHubRepo.get_test_result('unit', logfiles, col)
+        comment = GitHubRepo.add_test_to_text('unit', unit_col, col,
                                               logfiles, comment)
-        [int, int_col] = GitHubRepo.get_test_result('integration', logfiles,
+        int_col = GitHubRepo.get_test_result('integration', logfiles,
                                                     col)
-        comment = GitHubRepo.add_test_to_text('integration', int, int_col, col,
+        comment = GitHubRepo.add_test_to_text('integration', int_col, col,
                                               logfiles, comment)
-        [sys, sys_col] = GitHubRepo.get_test_result('system', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('system', sys, sys_col, col,
+        sys_col = GitHubRepo.get_test_result('system', logfiles, col)
+        comment = GitHubRepo.add_test_to_text('system', sys_col, col,
                                               logfiles, comment)
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -80,8 +80,9 @@ if __name__ == "__main__":
                 icon = ':red_circle:'
             comment += HTML.collapsible(f'{icon} {test_type} test', table)
 
-        if test_type == 'system' and not os.path.isfile(f'log/{machine_name()}/system_test/serial_test_run'):
-                comment += '\n\n**WARNING**: Serial tests did not run for system tests'
+        if test_type == 'system' and not os.path.isfile(
+                f'log/{machine_name()}/system_test/serial_test_run'):
+            comment += '\n\n**WARNING**: Serial tests did not run for system tests'
 
     if not any_tests_ran_on_machine:
         comment += f'No tests executed.'

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -76,14 +76,13 @@ if __name__ == "__main__":
 
         comment = f'###  {machine_name()}\n'
         unit_col = GitHubRepo.get_test_result('unit', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('unit', unit_col, col,
-                                              logfiles, comment)
-        int_col = GitHubRepo.get_test_result('integration', logfiles,
-                                                    col)
+        comment = GitHubRepo.add_test_to_text('unit', unit_col, col, logfiles,
+                                              comment)
+        int_col = GitHubRepo.get_test_result('integration', logfiles, col)
         comment = GitHubRepo.add_test_to_text('integration', int_col, col,
                                               logfiles, comment)
         sys_col = GitHubRepo.get_test_result('system', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('system', sys_col, col,
-                                              logfiles, comment)
+        comment = GitHubRepo.add_test_to_text('system', sys_col, col, logfiles,
+                                              comment)
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -88,12 +88,15 @@ if __name__ == "__main__":
 
         unit_col = ResultList.get_test_result('unit', logfiles, col)
         if unit_col:
-            comment = comment + GitHubRepo.add_test('unit', unit_col, col, logfiles)
+            comment = comment + GitHubRepo.add_test('unit', unit_col, col,
+                                                    logfiles)
         int_col = ResultList.get_test_result('integration', logfiles, col)
         if int_col:
-            comment = comment + GitHubRepo.add_test('integration', int_col, col, logfiles)
+            comment = comment + GitHubRepo.add_test('integration', int_col,
+                                                    col, logfiles)
         sys_col = ResultList.get_test_result('system', logfiles, col)
         if sys_col:
-            comment = comment + GitHubRepo.add_test('system', sys_col, col, logfiles)
+            comment = comment + GitHubRepo.add_test('system', sys_col, col,
+                                                    logfiles)
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -19,6 +19,15 @@ class ResultList:
         link = HTML.link(name, self.artifact_path + test)
         self.text += f'{status} {link} {comment}\n'
 
+    def get_test_result(test, logfiles, col):
+        if any(test in l for l in logfiles):
+            if all(c == ':green_circle:' for c in col):
+                test_col = ':green_circle:'
+            else:
+                test_col = ':red_circle:'
+        else:
+            test_col = None
+        return (test_col)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -75,13 +84,13 @@ if __name__ == "__main__":
             col.append(item.split()[0])
 
         comment = f'###  {machine_name()}\n'
-        unit_col = GitHubRepo.get_test_result('unit', logfiles, col)
+        unit_col = ResultList.get_test_result('unit', logfiles, col)
         comment = GitHubRepo.add_test_to_text('unit', unit_col, col, logfiles,
                                               comment)
-        int_col = GitHubRepo.get_test_result('integration', logfiles, col)
+        int_col = ResultList.get_test_result('integration', logfiles, col)
         comment = GitHubRepo.add_test_to_text('integration', int_col, col,
                                               logfiles, comment)
-        sys_col = GitHubRepo.get_test_result('system', logfiles, col)
+        sys_col = ResultList.get_test_result('system', logfiles, col)
         comment = GitHubRepo.add_test_to_text('system', sys_col, col, logfiles,
                                               comment)
 

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -4,8 +4,6 @@ import glob
 from github import GitHubRepo, Markdown, HTML
 from machine import machine_name
 
-spack_c2sm_path = os.path.dirname(os.path.realpath(__file__)) + '/..'
-
 
 class ResultList:
 
@@ -97,7 +95,7 @@ if __name__ == "__main__":
         if sys_col:
             comment = comment + GitHubRepo.add_test('system', sys_col, col,
                                                     logfiles)
-            path_to_sys = f'https://jenkins-mch.cscs.ch/job/Spack/job/spack_PR/{args.build_id}/artifact/log/{machine_name()}/system_test/'
+            path_to_sys = f'log/{machine_name()}/system_test/'
             if not os.path.isfile(os.path.join(path_to_sys,
                                                'serial_test_run')):
                 comment = comment + '\n \n **WARNING**: Serial tests did not run for system tests'

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -65,6 +65,32 @@ if __name__ == "__main__":
     if summary.text == '':
         comment = f'No tests ran on {machine_name()}.'
     else:
-        comment = summary.text
+        f = filter(None, summary.text.split('\n'))
+        text_lines = list(f)
+
+        details = []
+        logfiles = []
+        col = []
+        for item in text_lines:
+            details.append(item[item.find('[') + 1:item.rfind(']')])
+            logfiles.append(item[item.find('(') + 1:item.rfind(')')])
+            col.append(item.split()[0])
+
+        for i, item in enumerate(details):
+            details[i] = item.split('/')
+
+        text_new = '### ' + details[0][0] + '\n'
+
+        [unit, unit_col] = GitHubRepo.get_color('unit', details, col)
+        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, details,
+                                               col, logfiles, text_new)
+        [int, int_col] = GitHubRepo.get_color('integration', details, col)
+        text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
+                                               details, col, logfiles,
+                                               text_new)
+        [sys, sys_col] = GitHubRepo.get_color('system', details, col)
+        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, details,
+                                               col, logfiles, text_new)
+        comment = text_new
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
             logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
-        comment = Markdown.header(f'{machine_name()}',3)
+        comment = Markdown.header(f'{machine_name()}', 3)
         unit_col = ResultList.get_test_result('unit', logfiles, col)
         comment = GitHubRepo.add_test_to_text('unit', unit_col, col, logfiles,
                                               comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -29,6 +29,7 @@ class ResultList:
             test_col = None
         return (test_col)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--auth_token', type=str, required=False)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -76,17 +76,16 @@ if __name__ == "__main__":
             logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
-        text_new = f'###  {machine_name()}\n'
+        comment = f'###  {machine_name()}\n'
 
-        [unit, unit_col] = GitHubRepo.get_color('unit', logfiles, col)
-        text_new = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
-                                               logfiles, text_new)
-        [int, int_col] = GitHubRepo.get_color('integration', logfiles, col)
-        text_new = GitHubRepo.add_test_to_text('integration', int, int_col,
-                                               col, logfiles, text_new)
-        [sys, sys_col] = GitHubRepo.get_color('system', logfiles, col)
-        text_new = GitHubRepo.add_test_to_text('system', sys, sys_col, col,
-                                               logfiles, text_new)
-        comment = text_new
+        [unit, unit_col] = GitHubRepo.get_test_result('unit', logfiles, col)
+        comment = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
+                                               logfiles, comment)
+        [int, int_col] = GitHubRepo.get_test_result('integration', logfiles, col)
+        comment = GitHubRepo.add_test_to_text('integration', int, int_col,
+                                               col, logfiles, comment)
+        [sys, sys_col] = GitHubRepo.get_test_result('system', logfiles, col)
+        comment = GitHubRepo.add_test_to_text('system', sys, sys_col, col,
+                                               logfiles, comment)
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -98,7 +98,8 @@ if __name__ == "__main__":
             comment = comment + GitHubRepo.add_test('system', sys_col, col,
                                                     logfiles)
             path_to_sys = f'https://jenkins-mch.cscs.ch/job/Spack/job/spack_PR/{args.build_id}/artifact/log/{machine_name()}/system_test/'
-            if not os.path.isfile(os.path.join(path_to_sys, 'serial_test_run')):
+            if not os.path.isfile(os.path.join(path_to_sys,
+                                               'serial_test_run')):
                 comment = comment + '\n \n **WARNING**: Serial tests did not run for system tests'
 
     repo.comment(args.issue_id, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -67,17 +67,14 @@ if __name__ == "__main__":
     if summary.text == '':
         comment = f'No tests ran on {machine_name()}.'
     else:
-        f = filter(None, summary.text.split('\n'))
-        text_lines = list(f)
-
+        summary_rows= list(filter(None, summary.text.split('\n')))
         logfiles = []
         col = []
-        for item in text_lines:
+        for item in summary_rows:
             logfiles.append(item[item.find('<a'):item.rfind('a>') + 2])
             col.append(item.split()[0])
 
         comment = f'###  {machine_name()}\n'
-
         [unit, unit_col] = GitHubRepo.get_test_result('unit', logfiles, col)
         comment = GitHubRepo.add_test_to_text('unit', unit, unit_col, col,
                                               logfiles, comment)

--- a/src/report_tests.py
+++ b/src/report_tests.py
@@ -85,14 +85,15 @@ if __name__ == "__main__":
             col.append(item.split()[0])
 
         comment = Markdown.header(f'{machine_name()}', 3)
+
         unit_col = ResultList.get_test_result('unit', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('unit', unit_col, col, logfiles,
-                                              comment)
+        if unit_col:
+            comment = comment + GitHubRepo.add_test('unit', unit_col, col, logfiles)
         int_col = ResultList.get_test_result('integration', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('integration', int_col, col,
-                                              logfiles, comment)
+        if int_col:
+            comment = comment + GitHubRepo.add_test('integration', int_col, col, logfiles)
         sys_col = ResultList.get_test_result('system', logfiles, col)
-        comment = GitHubRepo.add_test_to_text('system', sys_col, col, logfiles,
-                                              comment)
+        if sys_col:
+            comment = comment + GitHubRepo.add_test('system', sys_col, col, logfiles)
 
     repo.comment(args.issue_id, comment)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -26,7 +26,7 @@ def spack_spec(spec: str, log_filename: str = None):
     Tests 'spack info' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
     """
-    log_filename = sanitized_filename(f'{spec}' + '-spack_spec')
+    log_filename = sanitized_filename(f'{spec}-spack_spec')
     ret = log_with_spack(f'spack spec {spec}', 'integration_test',
                          log_filename)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -16,7 +16,7 @@ def spack_info(spec: str, log_filename: str = None):
     Tests 'spack info' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
     """
-    log_filename = sanitized_filename(f'{spec}' + '-spack_info')
+    log_filename = sanitized_filename(f'{spec}-spack_info')
     ret = log_with_spack(f'spack info {spec}', 'integration_test',
                          log_filename)
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -2,12 +2,13 @@ import unittest
 import sys
 import os
 from pathlib import Path
+import inspect
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                '..')
 
 sys.path.append(os.path.normpath(spack_c2sm_path))
-from src import machine_name, log_with_spack
+from src import machine_name, log_with_spack, sanitized_filename
 
 
 def spack_info(spec: str, log_filename: str = None):
@@ -15,6 +16,7 @@ def spack_info(spec: str, log_filename: str = None):
     Tests 'spack info' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
     """
+    log_filename = sanitized_filename(f'{spec}' + '-spack_info')
     ret = log_with_spack(f'spack info {spec}', 'integration_test',
                          log_filename)
 
@@ -24,6 +26,7 @@ def spack_spec(spec: str, log_filename: str = None):
     Tests 'spack info' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
     """
+    log_filename = sanitized_filename(f'{spec}' + '-spack_spec')
     ret = log_with_spack(f'spack spec {spec}', 'integration_test',
                          log_filename)
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -40,8 +40,10 @@ def spack_install_and_test(spec: str,
     If log_filename is None, spec is used to create one.
     """
 
-    func_name = inspect.currentframe().f_back.f_code.co_name.replace('test_','')
-    class_name = inspect.currentframe().f_back.f_locals.get('self', None).__class__.__name__.replace('Test','')
+    func_name = inspect.currentframe().f_back.f_code.co_name.replace(
+        'test_', '')
+    class_name = inspect.currentframe().f_back.f_locals.get(
+        'self', None).__class__.__name__.replace('Test', '')
     log_filename = sanitized_filename(class_name + '-' + func_name)
 
     if spec.startswith('cosmo '):
@@ -86,8 +88,10 @@ def spack_devbuild_and_test(spec: str,
     If log_filename is None, spec is used to create one.
     """
 
-    func_name = inspect.currentframe().f_back.f_code.co_name.replace('test_','')
-    class_name = inspect.currentframe().f_back.f_locals.get('self', None).__class__.__name__.replace('Test','')
+    func_name = inspect.currentframe().f_back.f_code.co_name.replace(
+        'test_', '')
+    class_name = inspect.currentframe().f_back.f_locals.get(
+        'self', None).__class__.__name__.replace('Test', '')
     log_filename = sanitized_filename(class_name + '-' + func_name)
 
     if spec.startswith('cosmo '):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -5,6 +5,7 @@ import sys
 import os
 import uuid
 from pathlib import Path
+import inspect
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                '..')
@@ -39,7 +40,9 @@ def spack_install_and_test(spec: str,
     If log_filename is None, spec is used to create one.
     """
 
-    log_filename = sanitized_filename(log_filename or spec)
+    func_name = inspect.currentframe().f_back.f_code.co_name.replace('test_','')
+    class_name = inspect.currentframe().f_back.f_locals.get('self', None).__class__.__name__.replace('Test','')
+    log_filename = sanitized_filename(class_name + '-' + func_name)
 
     if spec.startswith('cosmo '):
         command = 'installcosmo'
@@ -82,7 +85,10 @@ def spack_devbuild_and_test(spec: str,
     Tests 'spack dev-build' of the given spec and writes the output into the log file.
     If log_filename is None, spec is used to create one.
     """
-    log_filename = sanitized_filename(log_filename or spec)
+
+    func_name = inspect.currentframe().f_back.f_code.co_name.replace('test_','')
+    class_name = inspect.currentframe().f_back.f_locals.get('self', None).__class__.__name__.replace('Test','')
+    log_filename = sanitized_filename(class_name + '-' + func_name)
 
     if spec.startswith('cosmo '):
         command = 'devbuildcosmo'

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                '..')
 sys.path.append(os.path.normpath(spack_c2sm_path))
-from src import machine_name, Markdown, time_format, sanitized_filename, all_machines, all_packages, explicit_scope, package_triggers
+from src import machine_name, Markdown, HTML, time_format, sanitized_filename, all_machines, all_packages, explicit_scope, package_triggers
 
 
 class MachineDetection(unittest.TestCase):
@@ -46,9 +46,21 @@ class MarkDownTest(unittest.TestCase):
                             ['data3', 'data4']]),
             'title1 | title2\n--- | ---\ndata1 | data2\ndata3 | data4')
 
+
+class HTMLTest(unittest.TestCase):
+
+    def test_link(self):
+        self.assertEqual(HTML.link('text', 'url'), '<a href="url">text</a>')
+
+    def test_table(self):
+        self.assertEqual(
+            HTML.table([['title1', 'title2'], ['data1', 'data2'],
+                            ['data3', 'data4']]),
+            '<table><thead><tr><th>title1</th><th>title2</th></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tr><td>data3</td><td>data4</td></tr></tbody></table>')
+
     def test_collapsible(self):
         self.assertEqual(
-            Markdown.collapsible('summary', 'details'),
+            HTML.collapsible('summary', 'details'),
             '<details><summary>summary</summary>details</details>')
 
 

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -55,8 +55,9 @@ class HTMLTest(unittest.TestCase):
     def test_table(self):
         self.assertEqual(
             HTML.table([['title1', 'title2'], ['data1', 'data2'],
-                            ['data3', 'data4']]),
-            '<table><thead><tr><th>title1</th><th>title2</th></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tr><td>data3</td><td>data4</td></tr></tbody></table>')
+                        ['data3', 'data4']]),
+            '<table><thead><tr><th>title1</th><th>title2</th></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tr><td>data3</td><td>data4</td></tr></tbody></table>'
+        )
 
     def test_collapsible(self):
         self.assertEqual(

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -42,8 +42,8 @@ class MarkDownTest(unittest.TestCase):
 
     def test_table(self):
         self.assertEqual(
-            Markdown.table([['title1', 'title2'], ['data1', 'data2'],
-                            ['data3', 'data4']]),
+            Markdown.table(['title1', 'title2'],
+                           [['data1', 'data2'], ['data3', 'data4']]),
             'title1 | title2\n--- | ---\ndata1 | data2\ndata3 | data4')
 
 
@@ -54,8 +54,8 @@ class HTMLTest(unittest.TestCase):
 
     def test_table(self):
         self.assertEqual(
-            HTML.table([['title1', 'title2'], ['data1', 'data2'],
-                        ['data3', 'data4']]),
+            HTML.table(['title1', 'title2'],
+                       [['data1', 'data2'], ['data3', 'data4']]),
             '<table><thead><tr><th>title1</th><th>title2</th></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tr><td>data3</td><td>data4</td></tr></tbody></table>'
         )
 


### PR DESCRIPTION
This pull request is meant to solve the issue [Report tests in a table](https://github.com/C2SM/spack-c2sm/issues/568).
- The output is shown differently than suggested (see outcome of launch jenkins below). The advantage is that one can see the output earlier than at the end of all tests and it's much easier to program. (I deleted old jenkins output, so that's clear what the final output looks like)
- If all tests on one machine of, for example, the integration tests are green, the collapsible is green, if one of the tests is red, locked, wastebasket or hourglass, the collapsible is red. If all tests are either green our yellow, the collapsible is yellow.
- The commit [Adds HTML string formatting](https://github.com/C2SM/spack-c2sm/commit/df94049d465a154bca1770bbad6fd4a34e02d508) was cherry-picked. Therefore, we should be cautious if the `html` branch will ever be merged to not mess up the history.
- A warning will be issued in case the serial test within the system test did not run. The reason is that in case the parallel test fails, the serial test will not be triggered. Thus, a package can look like it has passed all tests but actually the serial test has never been run.