### PR TITLE
[Daint] Include compiler version in install path

### DIFF
--- a/sysconfigs/daint/config.yaml
+++ b/sysconfigs/daint/config.yaml
@@ -6,6 +6,6 @@ config:
   misc_cache: '$spack/../spack-misc_cache'
   install_tree:
     projections:
-      all: '{name}/{version}/{compiler.name}/{hash}'
+      all: '{name}-{version}/{compiler.name}-{compiler.version}/{hash}'
   build_jobs: 12
   db_lock_timeout: 120


### PR DESCRIPTION
With regard to upstream I think it makes sense to inlcude the compiler version in the prefix.

To maintain the same depth of the install-tree, I merged package.name and package.version into the same level.