### PR TITLE
more actions for deployment of docs

### DIFF
--- a/.github/workflows/deploy_docs_to_latest.yml
+++ b/.github/workflows/deploy_docs_to_latest.yml
@@ -5,8 +5,8 @@ env:
 on:
   push:
     branches:    
-      - deploy_docs
       - master
+      - main
 
 jobs:
   deploy-docs:

--- a/.github/workflows/deploy_docs_to_latest.yml
+++ b/.github/workflows/deploy_docs_to_latest.yml
@@ -5,7 +5,7 @@ env:
 on:
   push:
     branches:    
-      - deploy
+      - deploy_docs
       - master
 
 jobs:

--- a/.github/workflows/deploy_docs_to_latest.yml
+++ b/.github/workflows/deploy_docs_to_latest.yml
@@ -5,7 +5,7 @@ env:
 on:
   push:
     branches:    
-      - main
+      - deploy
       - master
 
 jobs:

--- a/.github/workflows/deploy_docs_to_latest.yml
+++ b/.github/workflows/deploy_docs_to_latest.yml
@@ -1,15 +1,12 @@
-name: Deploy versioned docs
+name: Deploy docs to latest
 env:
-  # will be the subfolder of deployment in gh-pages
-  # change for each new version of spack-c2sm
-  DOCS_VERSION: v0.18.1.1
+  DOCS_VERSION: latest
 
 on:
   push:
     branches:    
-    # should point to a stable branch, ideally identical to DOCS_VERSION
-    # change for each new version of spack-c2sm
-      - v0.18.1.1
+      - main
+      - master
 
 jobs:
   deploy-docs:

--- a/.github/workflows/deploy_docs_to_tag.yml
+++ b/.github/workflows/deploy_docs_to_tag.yml
@@ -1,0 +1,30 @@
+name: Deploy docs to tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+         GITHUB_TOKEN: ${{ github.token }}
+      - name: Build docs
+        uses: C2SM/sphinx-action@sphinx-latest
+        with:
+          pre-build-command: "pip install sphinx_rtd_theme && pip install sphinx-copybutton"
+          build-command: "sphinx-build -b html . _build"
+          docs-folder: "docs/"
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build
+          destination_dir: ${{ steps.get_release.outputs.tag_name }}
+          allow_empty_commit: true


### PR DESCRIPTION
Push docs present in master/main branch here:
https://c2sm.github.io/spack-c2sm/latest/

Push docs for a tag (i.e 99.99) here:
https://c2sm.github.io/spack-c2sm/99.99

The action only works if the tag is created through the GitHub webpage as a release:
https://github.com/C2SM/spack-c2sm/releases
I anyway use to create tag through this interface.