### PR TITLE
[Icon] Enable out-of-source builds, skip configure-phase if icon.mk already present

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from llnl.util import lang, filesystem, tty
 from spack.util.environment import is_system_path, dump_environment
-from spack.util.executable import which_string,which
+from spack.util.executable import which_string, which
 
 
 class Icon(AutotoolsPackage):
@@ -768,7 +768,6 @@ class Icon(AutotoolsPackage):
         else:
             return self.stage.source_path
 
-
     def configure(self, spec, prefix):
         """Runs configure with the arguments specified in
         :meth:`~spack.build_systems.autotools.AutotoolsPackage.configure_args`
@@ -780,8 +779,7 @@ class Icon(AutotoolsPackage):
             return
 
         # use configure provided by Spack
-        AutotoolsPackage.configure(self,spec,prefix)
-
+        AutotoolsPackage.configure(self, spec, prefix)
 
     @run_after('configure')
     def copy_runscript_related_input_files(self):

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -769,9 +769,13 @@ class Icon(AutotoolsPackage):
             return self.stage.source_path
 
     def configure(self, spec, prefix):
-        if os.path.exists(os.path.join(self.build_directory, 'icon.mk')) and self.build_uses_same_spec():
-            tty.warn('icon.mk already present -> skip configure stage',
-                     '\t delete "icon.mk" or run "make distclean" to not skip configure')
+        if os.path.exists(
+                os.path.join(self.build_directory,
+                             'icon.mk')) and self.build_uses_same_spec():
+            tty.warn(
+                'icon.mk already present -> skip configure stage',
+                '\t delete "icon.mk" or run "make distclean" to not skip configure'
+            )
             return
 
         # use configure provided by Spack
@@ -787,10 +791,11 @@ class Icon(AutotoolsPackage):
         
         configure is skipped for the latter.
         """
-        
+
         is_same_spec = False
 
-        previous_spec = os.path.join(self.build_directory,'.previous_spec.yaml')
+        previous_spec = os.path.join(self.build_directory,
+                                     '.previous_spec.yaml')
 
         # not the first build in self.build_directory
         if os.path.exists(previous_spec):
@@ -799,7 +804,8 @@ class Icon(AutotoolsPackage):
                     is_same_spec = True
                 else:
                     is_same_spec = False
-                    tty.warn('Cannot skip configure phase because spec changed')
+                    tty.warn(
+                        'Cannot skip configure phase because spec changed')
 
         # first build in self.build_directory, no worries
         else:

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -769,13 +769,9 @@ class Icon(AutotoolsPackage):
             return self.stage.source_path
 
     def configure(self, spec, prefix):
-        """Runs configure with the arguments specified in
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.configure_args`
-        and an appropriately set prefix.
-        """
         if os.path.exists(os.path.join(self.build_directory, 'icon.mk')):
             tty.warn('icon.mk already present -> skip configure stage',
-                     '\t run "make distclean" to not skip configure')
+                     '\t delete "icon.mk to not skip configure')
             return
 
         # use configure provided by Spack


### PR DESCRIPTION
### Enable out-of-source build inside the git-repo
   - set `configure_directory` to git-root if different from `self.stage.source_path`
   - sync input-files for experiment following closely what is done in configure-wrappers
### Skip configure phase
  - Skip configure-phase if file `icon.mk` already present and spec is identical to previous installs
  - `make distclean` reset this behaviour, like you expect from build without Spack