### PR TITLE
FIX: add URL to cosmo-dycore package

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -6,7 +6,7 @@ class CosmoDycore(CMakePackage):
     """C++ dycore of cosmo based on GridTools library"""
 
     homepage = "https://github.com/COSMO-ORG/cosmo/tree/master/dycore"
-
+    url = "https://github.com/COSMO-ORG/cosmo/archive/6.0.tar.gz"
     git = "ssh://git@github.com/COSMO-ORG/cosmo.git"
     apngit = "ssh://git@github.com/MeteoSwiss-APN/cosmo.git"
     c2smgit = "ssh://git@github.com/C2SM-RCM/cosmo.git"


### PR DESCRIPTION
Otherwise spack fails complaining about a non-existing URL when compiling cosmo (the dycore gets installed properly): `==> Error: Can't extrapolate a URL for version dev-build because package cosmo-dycore defines no URLs`