### PR TITLE
[libxml2] Adds conflicts with nvidia compilers.

### DIFF
--- a/packages/libxml2/package.py
+++ b/packages/libxml2/package.py
@@ -1,0 +1,12 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+from spack.pkg.builtin.libxml2 import Libxml2 as SpackLibxml2
+
+
+class Libxml2(SpackLibxml2):
+    conflicts('%nvhpc @22.1:')
+    conflicts('%pgi')

--- a/packages/libxml2/package.py
+++ b/packages/libxml2/package.py
@@ -8,5 +8,5 @@ from spack.pkg.builtin.libxml2 import Libxml2 as SpackLibxml2
 
 
 class Libxml2(SpackLibxml2):
-    conflicts('%nvhpc @22.1:')
+    conflicts('%nvhpc @21.1:')
     conflicts('%pgi')

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -154,10 +154,6 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
-  libxml2:
-    externals:
-    - spec: libxml2@2.9.9 # manually added
-      prefix: /usr
   llvm:
     externals:
     - spec: llvm@10.0.0 # manually added


### PR DESCRIPTION
I dug a bit into libxml2.

Libxml2 never tested their software with pgi and de facto it doesn't work. (I tried several versions)

The versions of libxml2 in spack v0.18.1 are not compatible with `nvhpc @21.1:` because version 21.1 introduced something that broke compatibility. (A side effects from ["enabled via the compiler built-in type __float128"](https://docs.nvidia.com/hpc-sdk/archive/21.1/pdf/hpc-sdk211rn.pdf)) Newer versions of libxml2 are compatible with newer versions of nvhpc though.

I also removed `spec: libxml2@2.9.9` in Tsa's sysconfig, because IMHO not specifying the compiler, the package was build with, is just tricking spack into thinking it's a match, thus circumnavigating the logic of the concretizer. I think we shouldn't trick spack.

A valid argument against this PR is that one should rather put `^libxml%gcc` in the environment. But this means we'd need to put that in every environment that directly or indirectly needs libxml2, which is a lot. Plus it would force every build into using `libxml2 %gcc` even though a compatible nvhpc might be available and the compiler mixing would be unnecessary.
I think specifying the conflict in libxml2 treats the problem at the root, there's an incompatibility between some versions of nvhpc/pgi and some versions of libxml2.

I think this PR will also allow us to build icon@nwp-master on daint.