### PR TITLE
[Icon] introduce generic variant for --enable-fcgroup

### DIFF
--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -151,7 +151,8 @@ class Icon(AutotoolsPackage):
             default='none',
             multi=True,
             values=check_variant_fcgroup,
-            description='Create a Fortran compile group')
+            description=
+            'Create a Fortran compile group: GROUP;files;flag \nNote: flag can only be one single value, i.e. -O1')
 
     # C2SM specific Features:
     variant(

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -8,11 +8,11 @@ from spack.util.executable import which_string, which
 
 def check_variant_fcgroup(fcgroup):
     pattern = re.compile(r"^[A-Z]+;.+;.")
-    # fcgroup is False in case not set
+    # fcgroup is False as default
     if pattern.match(fcgroup) or fcgroup == 'none':
         return True
     else:
-        tty.warn('Variant fcgroup needs format GROUP;files;flags')
+        tty.warn('Variant fcgroup needs format GROUP;files;flag')
         return False
 
 
@@ -569,7 +569,8 @@ class Icon(AutotoolsPackage):
             libs += self.spec['infero'].libs
 
         fcgroup = self.spec.variants['fcgroup'].value
-        if fcgroup != 'none':
+        # ('none',) is the values spack assign if fcgroup is not set
+        if fcgroup != ('none',):
             config_args.extend(self.fcgroup_to_config_arg())
             config_vars.update(self.fcgroup_to_config_var())
 
@@ -652,9 +653,9 @@ class Icon(AutotoolsPackage):
         var = {}
         for group in self.spec.variants['fcgroup'].value:
             name = group.split(';')[0]
-            flags = group.split(';')[2]
-            # Note: flags needs to be a list
-            var[f'ICON_{name}_FCFLAGS'] = [flags]
+            flag = group.split(';')[2]
+            # Note: flag needs to be a list
+            var[f'ICON_{name}_FCFLAGS'] = [flag]
         return var
 
     @run_after('configure')

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -5,6 +5,7 @@ from llnl.util import lang, filesystem, tty
 from spack.util.environment import is_system_path, dump_environment
 from spack.util.executable import which_string, which
 
+
 def check_variant_fcgroup(fcgroup):
     pattern = re.compile(r"^[A-Z]+;.+;.")
     if pattern.match(fcgroup):
@@ -12,6 +13,7 @@ def check_variant_fcgroup(fcgroup):
     else:
         tty.warn('Variant fcgroup needs format GROUP;files;flags')
         return False
+
 
 class Icon(AutotoolsPackage):
     """Icosahedral Nonhydrostatic Weather and Climate Model."""
@@ -567,10 +569,8 @@ class Icon(AutotoolsPackage):
 
         fcgroup = self.spec.variants['fcgroup'].value
         if fcgroup != 'none':
-            config_args.extend(
-                self.fcgroup_to_config_arg())
-            config_vars.update(
-                self.fcgroup_to_config_var())
+            config_args.extend(self.fcgroup_to_config_arg())
+            config_vars.update(self.fcgroup_to_config_var())
 
         claw = self.spec.variants['claw'].value
         if claw == 'none':
@@ -655,7 +655,6 @@ class Icon(AutotoolsPackage):
             # Note: flags needs to be a list
             var[f'ICON_{name}_FCFLAGS'] = [flags]
         return var
-
 
     @run_after('configure')
     def adjust_rttov_macro(self):

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -142,10 +142,9 @@ class Icon(AutotoolsPackage):
 
     variant('fcgroup',
             default=False,
-            multi=True, 
+            multi=True,
             values=return_true,
             description='Create a Fortran compile group')
-
 
     # C2SM specific Features:
     variant(
@@ -564,8 +563,10 @@ class Icon(AutotoolsPackage):
 
         fcgroup = self.spec.variants['fcgroup'].value
         if fcgroup != 'none':
-            config_args.extend(self.extract_from_fcgroup(fcgroup,action='config_args'))
-            config_vars.update(self.extract_from_fcgroup(fcgroup,action='config_vars'))
+            config_args.extend(
+                self.extract_from_fcgroup(fcgroup, action='config_args'))
+            config_vars.update(
+                self.extract_from_fcgroup(fcgroup, action='config_vars'))
 
         claw = self.spec.variants['claw'].value
         if claw == 'none':
@@ -634,7 +635,7 @@ class Icon(AutotoolsPackage):
 
         return config_args
 
-    def extract_from_fcgroup(self,fcgroup,action):
+    def extract_from_fcgroup(self, fcgroup, action):
         flags_config_var = {}
         group_config_arg = []
         for group in fcgroup:
@@ -648,7 +649,6 @@ class Icon(AutotoolsPackage):
             return group_config_arg
         elif action == 'config_vars':
             return flags_config_var
-
 
     @run_after('configure')
     def adjust_rttov_macro(self):

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -147,12 +147,14 @@ class Icon(AutotoolsPackage):
             default=False,
             description='Ennable NCCL for communication')
 
-    variant('fcgroup',
-            default='none',
-            multi=True,
-            values=check_variant_fcgroup,
-            description=
-            'Create a Fortran compile group: GROUP;files;flag \nNote: flag can only be one single value, i.e. -O1')
+    variant(
+        'fcgroup',
+        default='none',
+        multi=True,
+        values=check_variant_fcgroup,
+        description=
+        'Create a Fortran compile group: GROUP;files;flag \nNote: flag can only be one single value, i.e. -O1'
+    )
 
     # C2SM specific Features:
     variant(

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -8,7 +8,8 @@ from spack.util.executable import which_string, which
 
 def check_variant_fcgroup(fcgroup):
     pattern = re.compile(r"^[A-Z]+;.+;.")
-    if pattern.match(fcgroup):
+    # fcgroup is False in case not set
+    if pattern.match(fcgroup) or fcgroup == 'none':
         return True
     else:
         tty.warn('Variant fcgroup needs format GROUP;files;flags')
@@ -147,7 +148,7 @@ class Icon(AutotoolsPackage):
             description='Ennable NCCL for communication')
 
     variant('fcgroup',
-            default=False,
+            default='none',
             multi=True,
             values=check_variant_fcgroup,
             description='Create a Fortran compile group')

--- a/packages/icon/package.py
+++ b/packages/icon/package.py
@@ -571,7 +571,7 @@ class Icon(AutotoolsPackage):
 
         fcgroup = self.spec.variants['fcgroup'].value
         # ('none',) is the values spack assign if fcgroup is not set
-        if fcgroup != ('none',):
+        if fcgroup != ('none', ):
             config_args.extend(self.fcgroup_to_config_arg())
             config_vars.update(self.fcgroup_to_config_var())
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -254,17 +254,17 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_cpu_gcc(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.1/daint_cpu_gcc', 'v2.6.6')
+            'config/cscs/spack/v0.18.1.1/daint_cpu_gcc', 'icon-2.6.6')
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_cpu(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.1/daint_cpu_nvhpc', 'v2.6.6')
+            'config/cscs/spack/v0.18.1.1/daint_cpu_nvhpc', 'icon-2.6.6')
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_gpu(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.1/daint_gpu_nvhpc', 'v2.6.6')
+            'config/cscs/spack/v0.18.1.1/daint_gpu_nvhpc', 'icon-2.6.6')
 
 
 @pytest.mark.no_balfrin  # int2lm depends on 'libgrib1 @22-01-2020', which fails.


### PR DESCRIPTION
### Introduce generic multi-value variant for `--enable-fcgroup`

**Single fcgroup**:
`fcgroup=DACE;externals/dace_icon;-O1`
**Multiple fcgroup**:
`fcgroup=DACE;externals/dace_icon;-O1,OCEAN;ocean/src;-02`

The grammar of the variant is checked using regex. It needs to be
`GROUP_NAME;files;flags`, separated by `;`

Testrun in ICON using this branch was succesfull with the new dace experiment:
https://gitlab.dkrz.de/icon/icon-nwp/-/pipelines/31976

**Limitations**:
When defining flags, each group is only allowed to hold one value for flags, i.e `-O1`,
because whitespaces corrupt the spec-parsing later on.

_A solution could be to separate the flags with `:` as it is done for files (implemented in configure of icon)._ 
**Edit JJ: This is not so easy, since in yaml `:` has a meaning, basically messing up the yaml-structure.**