### PR TITLE
Add new rttov upstream for Daint

### DIFF
--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -140,14 +140,6 @@ packages:
     externals:
     - spec: groff@1.22.3
       prefix: /usr
-  hdf5:
-    externals:
-    - spec: hdf5@1.12.0.4 ~mpi +hl # manually added
-      modules:
-      - cray-hdf5/1.12.0.4
-    - spec: hdf5@1.12.0.4 +mpi +hl # manually added
-      modules:
-      - cray-hdf5-parallel/1.12.0.4
   icontools: # manually added
     variants: slave=daint
   int2lm: # manually added

--- a/upstreams/daint/InstallUpstream
+++ b/upstreams/daint/InstallUpstream
@@ -12,6 +12,9 @@ pipeline {
                     . ./setup-env.sh
                     spack env activate upstreams/daint
                     spack install -v
+                    spack env activate upstreams/daint/rttov
+                    ln -s /some/jenkins-read-only/path/rttov131.tar.xz rttov131.tar.xz
+                    spack install -v
                     """
                 }
             }

--- a/upstreams/daint/rttov/spack.yaml
+++ b/upstreams/daint/rttov/spack.yaml
@@ -1,0 +1,17 @@
+spack:
+  specs:
+   # ICON + rttov
+    - rttov@13.1%nvhpc ~openmp +hdf5
+    - nvidia-blas%nvhpc
+    - nvidia-lapack%nvhpc
+    - pkg-config%gcc
+    - zlib%gcc
+    
+#    - netlib-lapack@3.10.1%nvhpc
+    - hdf5@1.12.2%nvhpc
+  concretizer:
+    unify: true
+  view: false
+  config:
+    install_tree:
+      root: /project/g110/spack/upstream/daint_v0.18.1.2


### PR DESCRIPTION
This is the attempt to have rttov prebuild on Daint in order to have it available ICON.

In order do compile rttov correctly, a clean version of hdf5 is necessary. Unfortunately, the version of hdf5 installed by Cray is not fully compatible with spack, so we need a version build by spack . Further, we pin dependencies of rttov in order to get the correction version for ICON.

TODO:
- [ ] store the `rttov131.tar.xz` somewhere and adjust `InstallUpstream` accordingly.

This PR corresponds to https://gitlab.dkrz.de/icon/icon-nwp/-/merge_requests/804 .