### PR TITLE
[cosmo-eccodes-definitions] Makes URLs https.

### DIFF
--- a/repos/c2sm/packages/cosmo-eccodes-definitions/package.py
+++ b/repos/c2sm/packages/cosmo-eccodes-definitions/package.py
@@ -27,8 +27,8 @@ class CosmoEccodesDefinitions(Package):
     """To simplify the usage of the GRIB 2 format within the COSMO Consortium, a COSMO GRIB 2 Policy has been defined. One element of this policy is to define a unified ecCodes system for the COSMO community, which is compatible with all COSMO software. This unified system is split into two parts, the vendor distribution of the ecCodes, available from ECMWF and the modified samples and definitions used by the COSMO consortium, available in the current repository."""
 
     homepage = "https://github.com/COSMO-ORG/eccodes-cosmo-resources.git"
-    url = "ssh://git@github.com/COSMO-ORG/eccodes-cosmo-resources.git"
-    git = 'ssh://git@github.com/COSMO-ORG/eccodes-cosmo-resources.git'
+    url = "https://github.com/COSMO-ORG/eccodes-cosmo-resources.git"
+    git = 'https://github.com/COSMO-ORG/eccodes-cosmo-resources.git'
 
     maintainers = ['egermann']
 


### PR DESCRIPTION
This enables ICON's buildbot to access cosmo-eccodes-definitions without any ssh credentials for GitHub.