### PR TITLE
Strip and configure input prompts for code cells

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,10 @@ templates_path = ['templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Copybutton prompt exceptions
+copybutton_prompt_text = r"\$ "
+copybutton_prompt_is_regexp = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Somehow since [version 0.18.1.4](https://c2sm.github.io/spack-c2sm/v0.18.1.4/QuickStart.html), the console input prompt `$` is being copied when clicking on the "copy" button within the docs.

It worked before, but we didn't explicitly set this in our `conf.py`. This PR solves this.

See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells