### PR TITLE
[icon] Adds variant async-io-rma and cuda-graphs.

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -375,6 +375,7 @@ class Icon(AutotoolsPackage):
                 'mixed-precision',
                 'pgi-inlib',
                 'nccl',
+                'cuda-graphs',
         ]:
             config_args += self.enable_or_disable(x)
 

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -102,7 +102,9 @@ class Icon(AutotoolsPackage):
         description=
         'Enable MPI active target mode (otherwise, passive target mode is used)'
     )
-    variant('async-io-rma', default=True, description='Enable remote memory access (RMA) for async I/O')
+    variant('async-io-rma',
+            default=True,
+            description='Enable remote memory access (RMA) for async I/O')
     variant('openmp', default=False, description='Enable OpenMP support')
 
     # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
@@ -150,12 +152,11 @@ class Icon(AutotoolsPackage):
         default=False,
         description=
         'Enable PGI/NVIDIA cross-file function inlining via an inline library')
-    variant('nccl',
-            default=False,
-            description='Enable NCCL for communication')
+    variant('nccl', default=False, description='Enable NCCL for communication')
     variant('cuda-graphs',
             default=False,
-            description='Enable CUDA graphs. Warning! This is an experimental feature')
+            description=
+            'Enable CUDA graphs. Warning! This is an experimental feature')
     variant(
         'fcgroup',
         default='none',

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -246,12 +246,12 @@ class Icon(AutotoolsPackage):
 
     conflicts('+dace', when='~mpi')
     conflicts('+emvorado', when='~mpi')
-    
-    conflicts('+cuda-graphs', when'%cce')
-    conflicts('+cuda-graphs', when'%gcc')
-    conflicts('+cuda-graphs', when'%intel')
-    conflicts('+cuda-graphs', when'%pgi')
-    conflicts('+cuda-graphs', when'%nvhpc@:23.2')
+
+    conflicts('+cuda-graphs', when='%cce')
+    conflicts('+cuda-graphs', when='%gcc')
+    conflicts('+cuda-graphs', when='%intel')
+    conflicts('+cuda-graphs', when='%pgi')
+    conflicts('+cuda-graphs', when='%nvhpc@:23.2')
 
     # Flag to mark if we build out-of-source
     # Needed to trigger sync of input files for experiments

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -152,8 +152,10 @@ class Icon(AutotoolsPackage):
         'Enable PGI/NVIDIA cross-file function inlining via an inline library')
     variant('nccl',
             default=False,
-            description='Ennable NCCL for communication')
-
+            description='Enable NCCL for communication')
+    variant('cuda-graphs',
+            default=False,
+            description='Enable CUDA graphs. Warning! This is an experimental feature')
     variant(
         'fcgroup',
         default='none',
@@ -244,6 +246,12 @@ class Icon(AutotoolsPackage):
 
     conflicts('+dace', when='~mpi')
     conflicts('+emvorado', when='~mpi')
+    
+    conflicts('+cuda-graphs', when'%cce')
+    conflicts('+cuda-graphs', when'%gcc')
+    conflicts('+cuda-graphs', when'%intel')
+    conflicts('+cuda-graphs', when'%pgi')
+    conflicts('+cuda-graphs', when'%nvhpc@:23.2')
 
     # Flag to mark if we build out-of-source
     # Needed to trigger sync of input files for experiments

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -102,6 +102,7 @@ class Icon(AutotoolsPackage):
         description=
         'Enable MPI active target mode (otherwise, passive target mode is used)'
     )
+    variant('async-io-rma', default=True, description='Enable remote memory access (RMA) for async I/O')
     variant('openmp', default=False, description='Enable OpenMP support')
 
     # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
@@ -354,6 +355,7 @@ class Icon(AutotoolsPackage):
                 'art',
                 'mpi',
                 'active-target-sync',
+                'async-io-rma',
                 'openmp',
                 'grib2',
                 'parallel-netcdf',


### PR DESCRIPTION
The need for `async-io-rma` stems from https://gitlab.dkrz.de/icon/icon-nwp/-/merge_requests/807
The need for `cuda-graphs` stems from https://gitlab.dkrz.de/icon/icon-nwp/-/merge_requests/716