### PR TITLE
Version bump to v0.18.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Spack is the package manager used by C2SM and MeteoSwiss to install and deploy s
 
 **Infos about c2sm-supported software and machines**
   * [spack-c2sm latest](https://C2SM.github.io/spack-c2sm/latest)
+  * [spack-c2sm v0.18.1.5](https://C2SM.github.io/spack-c2sm/v0.18.1.5)
   * [spack-c2sm v0.18.1.4](https://C2SM.github.io/spack-c2sm/v0.18.1.4)
   * [spack-c2sm v0.18.1.3](https://C2SM.github.io/spack-c2sm/v0.18.1.3)
   * [spack-c2sm v0.18.1.2](https://C2SM.github.io/spack-c2sm/v0.18.1.2)
@@ -20,7 +21,7 @@ With spack v0.18 we suggest local/individual spack instances and the use of spac
 
 A user clones the spack repo
 ```bash
-git clone --depth 1 --recurse-submodules --shallow-submodules -b v0.18.1.4 https://github.com/C2SM/spack-c2sm.git
+git clone --depth 1 --recurse-submodules --shallow-submodules -b v0.18.1.5 https://github.com/C2SM/spack-c2sm.git
 ```
 gets spack in the command line
 ```bash

--- a/docs/QuickStart.rst
+++ b/docs/QuickStart.rst
@@ -103,7 +103,7 @@ Example to build ICON for CPU with NVHPC:
 
 .. code-block:: console
 
-    $ spack env activate -p -d config/cscs/spack/v0.18.1.1/daint_cpu_nvhpc
+    $ spack env activate -p -d config/cscs/spack/v0.18.1.5/daint_cpu_nvhpc
     $ spack install
 
 ..  attention::
@@ -116,7 +116,7 @@ Out-of-source builds are possible as follows:
 
     $ mkdir cpu && cd cpu
     $ cp -r ../config .
-    $ spack env activate -p -d config/cscs/spack/v0.18.1.1/daint_cpu_nvhpc
+    $ spack env activate -p -d config/cscs/spack/v0.18.1.5/daint_cpu_nvhpc
     $ spack install
 
 ..  attention::

--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -10,7 +10,7 @@ This is a common way to do it.
 .. code-block:: console
 
     # cd into the packages repo!
-    $ git clone --depth 1 --recurse-submodules --shallow-submodules -b v0.18.1.4 https://github.com/C2SM/spack-c2sm.git
+    $ git clone --depth 1 --recurse-submodules --shallow-submodules -b v0.18.1.5 https://github.com/C2SM/spack-c2sm.git
     $ . spack-c2sm/setup-env.sh
     $ spack dev-build --test=root --show-log-on-error <package> @develop <variant>
 

--- a/sysconfigs/daint/upstreams.yaml
+++ b/sysconfigs/daint/upstreams.yaml
@@ -1,7 +1,7 @@
 upstreams:
   base:
-    install_tree: /project/g110/spack/upstream/daint_v0.18.1.4/base
+    install_tree: /project/g110/spack/upstream/daint_v0.18.1.5/base
   icon-dsl:
-    install_tree: /project/g110/spack/upstream/daint_v0.18.1.4/icon-dsl
+    install_tree: /project/g110/spack/upstream/daint_v0.18.1.5/icon-dsl
   icon-rttov:
-    install_tree: /project/g110/spack/upstream/daint_v0.18.1.4/icon-rttov
+    install_tree: /project/g110/spack/upstream/daint_v0.18.1.5/icon-rttov

--- a/test/unit_test.py
+++ b/test/unit_test.py
@@ -144,7 +144,7 @@ class UpstreamTest(unittest.TestCase):
         upstream_base = read_upstream_from_spack_yaml(
             os.path.join(os.path.normpath(spack_c2sm_path),
                          'upstreams/daint/base'))
-        self.assertEqual('/project/g110/spack/upstream/daint_v0.18.1.4/base',
+        self.assertEqual('/project/g110/spack/upstream/daint_v0.18.1.5/base',
                          upstream_base)
 
 

--- a/upstreams/daint/base/spack.yaml
+++ b/upstreams/daint/base/spack.yaml
@@ -26,4 +26,4 @@ spack:
   view: false
   config:
     install_tree:
-      root: /project/g110/spack/upstream/daint_v0.18.1.4/base
+      root: /project/g110/spack/upstream/daint_v0.18.1.5/base

--- a/upstreams/daint/icon-dsl/spack.yaml
+++ b/upstreams/daint/icon-dsl/spack.yaml
@@ -7,4 +7,4 @@ spack:
   view: false
   config:
     install_tree:
-      root: /project/g110/spack/upstream/daint_v0.18.1.4/icon-dsl
+      root: /project/g110/spack/upstream/daint_v0.18.1.5/icon-dsl

--- a/upstreams/daint/icon-rttov/spack.yaml
+++ b/upstreams/daint/icon-rttov/spack.yaml
@@ -12,4 +12,4 @@ spack:
   view: false
   config:
     install_tree:
-      root: /project/g110/spack/upstream/daint_v0.18.1.4/icon-rttov
+      root: /project/g110/spack/upstream/daint_v0.18.1.5/icon-rttov


### PR DESCRIPTION
For ICON's BB on Balfrin, MCH would like to test `icon ~async-io-rma`. Thus we need a new version.
@jonasjucker @mjaehn If this is okay with you, I'd merge and create the new release.