### PR TITLE
[Icon] enable silent rules for compilation

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -166,6 +166,12 @@ class Icon(AutotoolsPackage):
         'Create a Fortran compile group: GROUP;files;flag \nNote: flag can only be one single value, i.e. -O1'
     )
 
+    # verbosity
+    variant(
+        'silent-rules',
+        default=True,
+        description='Enable silent-rules for build-process')
+
     # C2SM specific Features:
     variant(
         'infero',
@@ -342,7 +348,7 @@ class Icon(AutotoolsPackage):
             f.writelines(['\n', '\n'.join(rules)])
 
     def configure_args(self):
-        config_args = ['--disable-rpaths', '--disable-silent-rules']
+        config_args = ['--disable-rpaths']
         config_vars = defaultdict(list)
         libs = LibraryList([])
 
@@ -376,6 +382,7 @@ class Icon(AutotoolsPackage):
                 'pgi-inlib',
                 'nccl',
                 'cuda-graphs',
+                'silent-rules',
         ]:
             config_args += self.enable_or_disable(x)
 

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -167,10 +167,9 @@ class Icon(AutotoolsPackage):
     )
 
     # verbosity
-    variant(
-        'silent-rules',
-        default=True,
-        description='Enable silent-rules for build-process')
+    variant('silent-rules',
+            default=True,
+            description='Enable silent-rules for build-process')
 
     # C2SM specific Features:
     variant(


### PR DESCRIPTION
Icon devs are confused by the verbosity of the spack output. This change brings the compilation output to what it used to be.