### PR TITLE
Adds sysconfigs for balfrin-devt.

### DIFF
--- a/sysconfigs/copy_alps_env_files_from.sh
+++ b/sysconfigs/copy_alps_env_files_from.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+parent_dir=$( cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" ; pwd -P )
+
+if [[ "$#" == 1 ]]; then
+    env_path="$1"
+    machine="$( "$parent_dir"/../src/machine.sh )"
+else
+    echo "Requires path to environment as argument!"
+    exit 0
+fi
+
+# Copy files
+cp "$env_path"/config/compilers.yaml "$parent_dir/$machine"
+cp "$env_path"/config/upstreams.yaml "$parent_dir/$machine"
+cp -r "$env_path"/repo/* "$parent_dir"/../repos/alps
+
+# Display success message
+echo "Files copied successfully."


### PR DESCRIPTION
This makes it possible to launch spack-c2sm with `. setup-env.sh balfrin-devt`, which uses a set of sysconfigs that point to `/mch-environment/devt` and uses a symbolic link to `/mch-environment/devt/config/compilers.yaml`. This simplifies the workflow when loading a squashfs for an experimental version of the software stack, because it's no longer needed to copy compilers.yaml and the repo into `spack-c2sm/repos/alps`.
The linking to `/mch-environment/devt` sacrifices reproducibility, since it's not under version control, but this is okay because it's an experimental version of the software stack anyway.