### PR TITLE
Adds bash script to copy the files from alp's environment.

### DIFF
--- a/sysconfigs/copy_alps_env_files_from.sh
+++ b/sysconfigs/copy_alps_env_files_from.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Intended use: ./sysconfigs/copy_alps_env_files_from.sh /mch-environment/v8
 
 parent_dir=$( cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" ; pwd -P )
 

--- a/sysconfigs/copy_alps_env_files_from.sh
+++ b/sysconfigs/copy_alps_env_files_from.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+parent_dir=$( cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" ; pwd -P )
+
+if [[ "$#" == 1 ]]; then
+    env_path="$1"
+    machine="$( "$parent_dir"/../src/machine.sh )"
+else
+    echo "Requires path to environment as argument!"
+    exit 0
+fi
+
+# Copy files
+cp "$env_path"/config/compilers.yaml "$parent_dir/$machine"
+cp "$env_path"/config/upstreams.yaml "$parent_dir/$machine"
+cp -r "$env_path"/repo/* "$parent_dir"/../repos/alps
+
+# Display success message
+echo "Files copied successfully."


### PR DESCRIPTION
Useful for updating or using with squashfs and `/mch-environment/devt`.
Intended use: `./sysconfigs/copy_alps_env_files_from.sh /mch-environment/v8`