### PR TITLE
[Upstream] include icon4py@0.0.4

### DIFF
--- a/upstreams/daint/icon-dsl/spack.yaml
+++ b/upstreams/daint/icon-dsl/spack.yaml
@@ -1,6 +1,7 @@
 spack:
   specs:
   - py-icon4py@0.0.3%gcc@9.3.0
+  - py-icon4py@0.0.4%gcc@9.3.0
   - py-gt4py@1.1.1%gcc@9.3.0
   concretizer:
     unify: true


### PR DESCRIPTION
Requires a new installation of the upstream "icon-dsl"

This happens when new release is published