### PR TITLE
[Icon] make CMake a build dependency

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -227,6 +227,7 @@ class Icon(AutotoolsPackage, CudaPackage):
 
     depends_on('python', type='build')
     depends_on('perl', type='build')
+    depends_on('cmake@3.18:', type='build')
 
     for x in claw_values:
         depends_on('claw', type='build', when='claw={0}'.format(x))


### PR DESCRIPTION
This is needed for externals built with CMake, as implemented here:
https://gitlab.dkrz.de/icon/icon-mpim/-/merge_requests/145