### PR TITLE
[icon] Adds variant 'gpu'

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -109,7 +109,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             default=False,
             description='Enable usage of the GPU-aware MPI features')
     variant('openmp', default=False, description='Enable OpenMP support')
-    variant('gpu', default='no', values=('openacc+cuda', 'openacc+hip', 'openacc', 'yes', 'no'), description='Enable GPU support')
+    variant('gpu', default='no', values=('openacc+cuda', 'openacc', 'yes', 'no'), description='Enable GPU support')
     variant('grib2', default=False, description='Enable GRIB2 I/O')
     variant('parallel-netcdf',
             default=False,
@@ -250,7 +250,6 @@ class Icon(AutotoolsPackage, CudaPackage):
     conflicts('+cuda', when='%gcc')
 
     conflicts('~cuda', when='gpu=openacc+cuda')
-    conflicts('+cuda', when='gpu=openacc+hip')
     conflicts('~cuda', when='gpu=openacc')
     conflicts('~cuda', when='gpu=yes')
     conflicts('+cuda', when='gpu=no')

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -109,6 +109,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             default=False,
             description='Enable usage of the GPU-aware MPI features')
     variant('openmp', default=False, description='Enable OpenMP support')
+    variant('gpu', default='no', values=('openacc+cuda', 'openacc+hip', 'openacc', 'yes', 'no'), description='Enable GPU support')
     variant('grib2', default=False, description='Enable GRIB2 I/O')
     variant('parallel-netcdf',
             default=False,
@@ -220,6 +221,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     depends_on('lapack')
     depends_on('blas')
     depends_on('netcdf-fortran')
+    depends_on('hip', when='gpu=openacc+hip')
 
     depends_on('netcdf-c', when='~cdi-pio')
     depends_on('netcdf-c', when='+coupling')
@@ -246,6 +248,12 @@ class Icon(AutotoolsPackage, CudaPackage):
     conflicts('+dace', when='~mpi')
     conflicts('+emvorado', when='~mpi')
     conflicts('+cuda', when='%gcc')
+
+    conflicts('~cuda', when='gpu=openacc+cuda')
+    conflicts('+cuda', when='gpu=openacc+hip')
+    conflicts('~cuda', when='gpu=openacc')
+    conflicts('~cuda', when='gpu=yes')
+    conflicts('+cuda', when='gpu=no')
 
     conflicts('+cuda-graphs', when='%cce')
     conflicts('+cuda-graphs', when='%gcc')

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -109,7 +109,10 @@ class Icon(AutotoolsPackage, CudaPackage):
             default=False,
             description='Enable usage of the GPU-aware MPI features')
     variant('openmp', default=False, description='Enable OpenMP support')
-    variant('gpu', default='no', values=('openacc+cuda', 'openacc', 'yes', 'no'), description='Enable GPU support')
+    variant('gpu',
+            default='no',
+            values=('openacc+cuda', 'openacc', 'yes', 'no'),
+            description='Enable GPU support')
     variant('grib2', default=False, description='Enable GRIB2 I/O')
     variant('parallel-netcdf',
             default=False,

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -221,7 +221,6 @@ class Icon(AutotoolsPackage, CudaPackage):
     depends_on('lapack')
     depends_on('blas')
     depends_on('netcdf-fortran')
-    depends_on('hip', when='gpu=openacc+hip')
 
     depends_on('netcdf-c', when='~cdi-pio')
     depends_on('netcdf-c', when='+coupling')

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -408,7 +408,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             config_vars['FCFLAGS'].extend(
                 ['-g', '-O', '-Mrecursive', '-Mallocatable=03', '-Mbackslash'])
 
-            if self.spec.variants['gpu'].value=='openacc+cuda':
+            if self.spec.variants['gpu'].value == 'openacc+cuda':
                 config_vars['FCFLAGS'].extend([
                     '-acc=verystrict', '-Minfo=accel,inline',
                     '-gpu=cc{0}'.format(
@@ -424,7 +424,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 '-hadd_paren', '-r am', '-Ktrap=divz,ovf,inv',
                 '-hflex_mp=intolerant', '-hfp0', '-O0'
             ])
-            if self.spec.variants['gpu'].value=='openacc+cuda':
+            if self.spec.variants['gpu'].value == 'openacc+cuda':
                 config_vars['FCFLAGS'].extend(['-hacc'])
         elif self.compiler.name == 'aocc':
             config_vars['CFLAGS'].extend(['-g', '-O2'])
@@ -530,7 +530,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 config_vars['CLAWFLAGS'].append(
                     self.spec['libcdi-pio'].headers.include_flags)
 
-        gpu=self.spec.variants['gpu'].value
+        gpu = self.spec.variants['gpu'].value
         if gpu == 'no':
             config_args.append('--disable-gpu')
         elif gpu == 'openacc+cuda':

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -530,6 +530,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                     self.spec['libcdi-pio'].headers.include_flags)
 
         # Set GPU compilation.  Both gpu=openacc and +cuda are needed
+        gpu=self.spec.variants['gpu'].value
         if gpu == 'no':
             config_args.append('--disable-gpu')
         elif gpu == 'openacc' and self.spec.variants['cuda'].value:

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -533,7 +533,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         gpu = self.spec.variants['gpu'].value
         if gpu == 'no':
             config_args.append('--disable-gpu')
-        elif gpu == 'openacc+cuda':
+        else:
             config_args.extend([
                 '--enable-gpu={0}'.format(gpu), '--disable-loop-exchange',
                 'NVCC={0}'.format(self.spec['cuda'].prefix.bin.nvcc)

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -556,10 +556,6 @@ class Icon(AutotoolsPackage, CudaPackage):
             # flags (i.e. not the linker -l<library> flags), therefore we put
             # the value to the config_flags directly.
             config_vars['LIBS'].extend(cuda_host_compiler_stdcxx_libs)
-        else:
-            raise error.UnsupportedPlatformError(
-                'only gpu=openacc with +cuda supported with spack for gpu build'
-            )
 
         # Check for DSL variants and set corresponding Liskov options
         dsl = self.spec.variants['dsl'].value


### PR DESCRIPTION
The variant "gpu" follows closer the configure of icon.
This change is required to use --enable-gpu=openacc for the configure script in ICON