### PR TITLE
[gt4py] add version 1.1.2 from c2sm-fork

### DIFF
--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -14,9 +14,11 @@ class PyGt4py(PythonPackage):
     homepage = "https://gridtools.github.io/gt4py/latest/index.html"
 
     url = "ssh://git@github.com/GridTools/gt4py.git"
+    url_c2sm = "ssh://git@github.com/C2SM/gt4py.git"
 
     version('main', branch='main', git=url)
     version('1.1.1', tag='icon4py_20230413', git=url)
+    version('1.1.2', tag='icon4py_20230706', git=url_c2sm)
 
     maintainers = ['samkellerhals']
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -545,6 +545,9 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_1_1(self):
         spack_install_and_test('py-gt4py @1.1.1')
 
+    def test_install_version_1_1_2(self):
+        spack_install_and_test('py-gt4py @1.1.2')
+
 
 class PyHatchlingTest(unittest.TestCase):
 


### PR DESCRIPTION
New version (living in c2sm-fork) before introduction of Dace backend for next, that will requires some API-change in the package.