### PR TITLE
Update FDB Flexpart package.py

### DIFF
--- a/repos/c2sm/packages/fdb-flexpart/package.py
+++ b/repos/c2sm/packages/fdb-flexpart/package.py
@@ -6,7 +6,7 @@ class FdbFlexpart(MakefilePackage):
     """flexpart is a Lagrangian dispersion model"""
 
     homepage = 'https://github.com/MeteoSwiss-APN/fdb-flexpart'
-    git = 'ssh://git@github.com/MeteoSwiss-APN/fdb-flexpart.git'
+    git = 'git@github.com/MeteoSwiss-APN/fdb-flexpart.git'
 
     version('fdb', branch='fdb')
 


### PR DESCRIPTION
I am using spack in a container. On build, spack installs various dependencies, some of which use private repos for which we should provide a git token to authenticate. (Getting ssh to work in build without copying the private keys turned out to be not possible)
The way I work around this is to transform all the git protocol urls into HTTPS authenticated with a token, eg.

```
RUN git config --global url."https://x-access-token:${TOKEN}@github.com/MeteoSwiss-APN/".insteadOf "git@github.com:MeteoSwiss-APN/"
RUN git config --global url."https://x-access-token:${TOKEN}@github.com/MeteoSwiss-APN/".insteadOf "https://github.com/MeteoSwiss-APN/"
```

This doesn't work when the url of the git repo starts with `ssh://`
Opening this PR for fdb-flexpart, to discuss whether we need this ssh:// or what are the other possibilities. 