### PR TITLE
[icon] Bugfix for +art ~coupling.

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -457,6 +457,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 ]
                 config_vars['CPPFLAGS'].append(xml2_headers.include_flags)
 
+        if '+coupling' in self.spec:
             libs += self.spec['libfyaml'].libs
 
         serialization = self.spec.variants['serialization'].value


### PR DESCRIPTION
Icon `depends_on('libfyaml', when='+coupling')` but consumed libfyaml also if `+art`.