### PR TITLE
[icon] move call to test.py after install-phase

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -660,7 +660,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         # Therefore override this function, saves a lot of time too.
         pass
 
-    @run_before('install')
+    @run_after('install')
     @on_package_attributes(run_tests=True)
     def checksuite(self):
         # script needs cdo to work, but not listed as dep of ICON


### PR DESCRIPTION
Like that the information about test failed or passed is at the end of the log-file.