### PR TITLE
[icon-ham] Fix filepath to HAMMOZ namelists for out-of-source builds

### DIFF
--- a/repos/c2sm/packages/icon-ham/package.py
+++ b/repos/c2sm/packages/icon-ham/package.py
@@ -6,7 +6,8 @@ class IconHam(C2SMIcon):
 
     @run_before('build')
     def generate_hammoz_nml(self):
-        with working_dir(self.configure_directory + '/externals/atm_phy_echam_submodels/namelists'):
+        with working_dir(self.configure_directory +
+                         '/externals/atm_phy_echam_submodels/namelists'):
             make()
 
     def configure_args(self):

--- a/repos/c2sm/packages/icon-ham/package.py
+++ b/repos/c2sm/packages/icon-ham/package.py
@@ -6,7 +6,7 @@ class IconHam(C2SMIcon):
 
     @run_before('build')
     def generate_hammoz_nml(self):
-        with working_dir('./externals/atm_phy_echam_submodels/namelists'):
+        with working_dir(self.configure_directory + '/externals/atm_phy_echam_submodels/namelists'):
             make()
 
     def configure_args(self):


### PR DESCRIPTION
This fix by @dominichofer allows for out-of-source builds for the icon-ham package. The path to the namelists directory was pointing to the respective copy in the build folder (for out-of-source builds), however it should point to the original namelists directory at the icon root. To achieve this we join the absolute path with the `configure_directory` property.