### PR TITLE
[py-icon4py, icon] Modifications for merge of advection

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -596,6 +596,9 @@ class Icon(AutotoolsPackage, CudaPackage):
                 config_vars['LOC_ICON4PY_INTERPOLATION'].append(
                     self.spec['py-icon4py:interpolation'].headers.
                     directories[0])
+            if self.spec['py-icon4py'].version > Version("0.0.8"):
+                config_vars['LOC_ICON4PY_ADVECTION'].append(
+                    self.spec['py-icon4py:advection'].headers.directories[0])
             config_vars['LOC_GRIDTOOLS'].append(
                 self.spec['py-gridtools-cpp:data'].headers.directories[0])
             config_vars['GT4PYNVCFLAGS'] = config_vars['NVCFLAGS']

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -18,7 +18,8 @@ class PyGt4py(PythonPackage):
     version('main', branch='main', git=url)
     version('1.1.1', tag='icon4py_20230413', git=url)
     version('1.1.2', tag='icon4py_20230621', git=url)
-    version('1.1.3', tag='icon4py_20230926', git=url)
+    version('1.1.3', tag='icon4py_20230817', git=url)
+    version('1.1.4', tag='icon4py_20230926', git=url)
 
     maintainers = ['samkellerhals']
 

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -18,7 +18,7 @@ class PyGt4py(PythonPackage):
     version('main', branch='main', git=url)
     version('1.1.1', tag='icon4py_20230413', git=url)
     version('1.1.2', tag='icon4py_20230621', git=url)
-    version('1.1.3', tag='icon4py_20230817', git=url)
+    version('1.1.3', tag='icon4py_20230926', git=url)
 
     maintainers = ['samkellerhals']
 

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -66,7 +66,8 @@ class PyIcon4py(PythonPackage):
 
         # unit tests
         if 'py-pytest-mpi' in self.spec:
-            python('-m', 'pytest', '--with-mpi', '-v', '-s', '-m', 'not slow_tests')
+            python('-m', 'pytest', '--with-mpi', '-v', '-s', '-m',
+                   'not slow_tests')
         else:
             python('-m', 'pytest', '-v', '-s', '-n', 'auto')
 

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -21,7 +21,7 @@ class PyIcon4py(PythonPackage):
 
     homepage = "https://github.com/C2SM/icon4py"
 
-    maintainers = ['agopal','samkellerhals']
+    maintainers = ['agopal', 'samkellerhals']
 
     version('main', branch='main', git=git)
     version('0.0.3', tag='v0.0.3', git=git)

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -21,7 +21,7 @@ class PyIcon4py(PythonPackage):
 
     homepage = "https://github.com/C2SM/icon4py"
 
-    maintainers = ['samkellerhals']
+    maintainers = ['agopal','samkellerhals']
 
     version('main', branch='main', git=git)
     version('0.0.3', tag='v0.0.3', git=git)
@@ -29,6 +29,7 @@ class PyIcon4py(PythonPackage):
     version('0.0.5', tag='v0.0.5', git=git)
     version('0.0.6', tag='v0.0.6', git=git)
     version('0.0.7', tag='v0.0.7', git=git)
+    version('0.0.8', tag='v0.0.8', git=git)
 
     depends_on('py-wheel', type='build')
     depends_on('py-setuptools', type='build')

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -66,7 +66,7 @@ class PyIcon4py(PythonPackage):
 
         # unit tests
         if 'py-pytest-mpi' in self.spec:
-            python('-m', 'pytest', '--with-mpi', '-v', '-s')
+            python('-m', 'pytest', '--with-mpi', '-v', '-s', '-m', 'not slow_tests')
         else:
             python('-m', 'pytest', '-v', '-s', '-n', 'auto')
 
@@ -97,11 +97,18 @@ class PyIcon4py(PythonPackage):
                 'atm_dyn_iconam': 'dycore',
                 'tools': 'icon4pytools'
             },
+            ver('=0.0.8'): {
+                'atm_dyn_iconam': 'dycore',
+                'tools': 'icon4pytools',
+                'diffusion': 'diffusion/stencils',
+                'interpolation': 'interpolation/stencils',
+            },
             ver('=main'): {
                 'atm_dyn_iconam': 'dycore',
                 'tools': 'icon4pytools',
                 'diffusion': 'diffusion/stencils',
                 'interpolation': 'interpolation/stencils',
+                'advection': 'advection',
             },
         }
 
@@ -169,10 +176,16 @@ class PythonPipBuilder(PythonPipBuilder):
         elif self.spec.version == ver('=0.0.6') or self.spec.version == ver(
                 '=0.0.7'):
             build_dirs = ['tools', 'model/atmosphere/dycore', 'model/common/']
-        else:
+        elif self.spec.version == ver('=0.0.8'):
             build_dirs = [
                 'tools', 'model/atmosphere/dycore',
                 'model/atmosphere/diffusion', 'model/driver', 'model/common/'
+            ]
+        else:
+            build_dirs = [
+                'tools', 'model/atmosphere/dycore',
+                'model/atmosphere/diffusion', 'model/atmosphere/advection',
+                'model/driver', 'model/common/'
             ]
 
         for dir in build_dirs:

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -650,7 +650,7 @@ class PyGt4pyTest(unittest.TestCase):
 
     def test_install_version_1_1_2(self):
         spack_install_and_test('py-gt4py @1.1.2')
-      
+
     @pytest.mark.no_daint  # fails with ModuleNotFoundError: No module named 'dace'
     @pytest.mark.no_balfrin  # fails with ModuleNotFoundError: No module named 'dace'
     def test_install_version_1_1_3(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -651,8 +651,6 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_1_2(self):
         spack_install_and_test('py-gt4py @1.1.2')
 
-    @pytest.mark.no_daint  # fails with ModuleNotFoundError: No module named 'dace'
-    @pytest.mark.no_balfrin  # fails with ModuleNotFoundError: No module named 'dace'
     def test_install_version_1_1_3(self):
         spack_install_and_test('py-gt4py @1.1.3')
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -676,6 +676,10 @@ class PyIcon4pyTest(unittest.TestCase):
         spack_install_and_test(
             'py-icon4py @ 0.0.7 %gcc ^py-gt4py@1.1.3 ^python@3.10.4')
 
+    def test_install_version_0_0_8(self):
+        spack_install_and_test(
+            'py-icon4py @ 0.0.8 %gcc ^py-gt4py@1.1.3 ^python@3.10.4')
+
 
 class PyInflectionTest(unittest.TestCase):
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -650,9 +650,14 @@ class PyGt4pyTest(unittest.TestCase):
 
     def test_install_version_1_1_2(self):
         spack_install_and_test('py-gt4py @1.1.2')
-
+      
+    @pytest.mark.no_daint  # fails with ModuleNotFoundError: No module named 'dace'
+    @pytest.mark.no_balfrin  # fails with ModuleNotFoundError: No module named 'dace'
     def test_install_version_1_1_3(self):
         spack_install_and_test('py-gt4py @1.1.3')
+
+    def test_install_version_1_1_4(self):
+        spack_install_and_test('py-gt4py @1.1.4')
 
 
 class PyHatchlingTest(unittest.TestCase):
@@ -676,7 +681,7 @@ class PyIcon4pyTest(unittest.TestCase):
 
     def test_install_version_0_0_8(self):
         spack_install_and_test(
-            'py-icon4py @ 0.0.8 %gcc ^py-gt4py@1.1.3 ^python@3.10.4')
+            'py-icon4py @ 0.0.8 %gcc ^py-gt4py@1.1.4 ^python@3.10.4')
 
 
 class PyInflectionTest(unittest.TestCase):


### PR DESCRIPTION
Adapt the icon4py spack recipe to test the advection component. These changes are valid for icon4py releases higher than [v0.0.8](https://github.com/C2SM/icon4py/releases/tag/v0.0.8). The arguments ` '-m',  'not slow_tests'` are added to the `pytest ` command  to ignore the four slow advection stencils for the testing.