### PR TITLE
Sets concretizer:reuse:true for all sysconfigs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
         "-p",
         "*_test.py"
     ],
-    "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "test"
+    ]
 }

--- a/sysconfigs/balfrin/concretizer.yaml
+++ b/sysconfigs/balfrin/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/daint/concretizer.yaml
+++ b/sysconfigs/daint/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/dom/concretizer.yaml
+++ b/sysconfigs/dom/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/eiger/concretizer.yaml
+++ b/sysconfigs/eiger/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/tasna/concretizer.yaml
+++ b/sysconfigs/tasna/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/tsa/concretizer.yaml
+++ b/sysconfigs/tsa/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/sysconfigs/unknown/concretizer.yaml
+++ b/sysconfigs/unknown/concretizer.yaml
@@ -1,0 +1,2 @@
+concretizer:
+  reuse: true

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,9 +44,6 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(
                     pytest.mark.skip(
                         reason="test is marked to run in serial mode only"))
-        else:
-            raise ValueError(
-                'please define "parallel" or "serial" in your scope')
 
         if not any(k in triggers for k in keywords):
             item.add_marker(pytest.mark.skip(reason="test not in scope"))


### PR DESCRIPTION
Addresses https://github.com/C2SM/spack-c2sm/issues/843

Removes the value error if neither parallel nor serial testing is set, because local testing with VSCode doesn't have nor needs this separation.
Adapts the .vscode setting to the recent changes in VSCode.