### PR TITLE
Gt4py version 1015

### DIFF
--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -21,7 +21,7 @@ class PyGt4py(PythonPackage):
     version('1.0.1.2', tag='icon4py_20230621', git=url)
     version('1.0.1.3', tag='icon4py_20230817', git=url)
     version('1.0.1.4', tag='icon4py_20230926', git=url)
-    version('1.0.1.5', tag='icon4py_20231026', git=url)
+    version('1.0.1.5', tag='icon4py_20231027', git=url)
 
     maintainers = ['samkellerhals']
 

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -86,5 +86,4 @@ class PyGt4py(PythonPackage):
     depends_on('py-pytest-xdist', type=('build', 'run'))
 
     def test(self):
-        python('-m', 'pytest', '-v', '-s', '-n', 'auto', '--cov',
-               '--cov-append', 'tests/next_tests', 'tests/eve_tests')
+        python('-m', 'pytest', '-v', '-s', '-n', 'auto', '-k', '[otf_compile_executor.run_gtfn]', 'tests/next_tests', 'tests/eve_tests')

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -86,4 +86,6 @@ class PyGt4py(PythonPackage):
     depends_on('py-pytest-xdist', type=('build', 'run'))
 
     def test(self):
-        python('-m', 'pytest', '-v', '-s', '-n', 'auto', '-k', '[otf_compile_executor.run_gtfn]', 'tests/next_tests', 'tests/eve_tests')
+        python('-m', 'pytest', '-v', '-s', '-n', 'auto', '-k',
+               '[otf_compile_executor.run_gtfn]', 'tests/next_tests',
+               'tests/eve_tests')

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -21,6 +21,7 @@ class PyGt4py(PythonPackage):
     version('1.0.1.2', tag='icon4py_20230621', git=url)
     version('1.0.1.3', tag='icon4py_20230817', git=url)
     version('1.0.1.4', tag='icon4py_20230926', git=url)
+    version('1.0.1.5', tag='icon4py_20231026', git=url)
 
     maintainers = ['samkellerhals']
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -625,7 +625,7 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_0_1_4(self):
         spack_install_and_test('py-gt4py @1.0.1.4')
 
-    def test_install_version_1_0_1_4(self):
+    def test_install_version_1_0_1_5(self):
         spack_install_and_test('py-gt4py @1.0.1.5')
 
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -625,6 +625,9 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_0_1_4(self):
         spack_install_and_test('py-gt4py @1.0.1.4')
 
+    def test_install_version_1_0_1_4(self):
+        spack_install_and_test('py-gt4py @1.0.1.5')
+
 
 class PyHatchlingTest(unittest.TestCase):
 


### PR DESCRIPTION
udpates to gt4py recipe: 
- new gt4py version 1.0.15

As for the `py-icon4py` package in order to reduce the dependencies of the `py-gt4py` package by reduceing  the tests being run to those relevant for `icon-dsl`: 

`gt4py` supports quite a few backends now: dace, gpu, gtfn, python but `icon-dsl` uses the `gtfn` backend for code generation through `icon4py`.

code coverage has been removed from the test run, it is relevant for `gt4py` development but not for spack packaging.  


