### PR TITLE
Add spack spec to log

### DIFF
--- a/test/system_test.py
+++ b/test/system_test.py
@@ -50,9 +50,9 @@ def spack_install(spec: str, log_filename: str = None):
         devirtualize_env()
 
     log_with_spack(f'spack spec {spec}',
-        'system_test',
-        log_filename,
-        srun=False)
+                   'system_test',
+                   log_filename,
+                   srun=False)
     log_with_spack(f'spack {command} -n -v {spec}',
                    'system_test',
                    log_filename,
@@ -79,9 +79,9 @@ def spack_install_and_test(spec: str,
         devirtualize_env()
 
     log_with_spack(f'spack spec {spec}',
-        'system_test',
-        log_filename,
-        srun=False)
+                   'system_test',
+                   log_filename,
+                   srun=False)
     if split_phases:
         log_with_spack(
             f'spack {command} --until build --test=root -n -v {spec}',

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -49,6 +49,10 @@ def spack_install(spec: str, log_filename: str = None):
     if spec.startswith('py-'):
         devirtualize_env()
 
+    log_with_spack('spack spec {spec}'
+        'system_test',
+        log_filename,
+        srun=False)
     log_with_spack(f'spack {command} -n -v {spec}',
                    'system_test',
                    log_filename,
@@ -74,6 +78,10 @@ def spack_install_and_test(spec: str,
     if spec.startswith('py-'):
         devirtualize_env()
 
+    log_with_spack('spack spec {spec}'
+        'system_test',
+        log_filename,
+        srun=False)
     if split_phases:
         log_with_spack(
             f'spack {command} --until build --test=root -n -v {spec}',

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -49,7 +49,7 @@ def spack_install(spec: str, log_filename: str = None):
     if spec.startswith('py-'):
         devirtualize_env()
 
-    log_with_spack(f'spack spec {spec}'
+    log_with_spack(f'spack spec {spec}',
         'system_test',
         log_filename,
         srun=False)
@@ -78,7 +78,7 @@ def spack_install_and_test(spec: str,
     if spec.startswith('py-'):
         devirtualize_env()
 
-    log_with_spack(f'spack spec {spec}'
+    log_with_spack(f'spack spec {spec}',
         'system_test',
         log_filename,
         srun=False)

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -49,7 +49,7 @@ def spack_install(spec: str, log_filename: str = None):
     if spec.startswith('py-'):
         devirtualize_env()
 
-    log_with_spack('spack spec {spec}'
+    log_with_spack(f'spack spec {spec}'
         'system_test',
         log_filename,
         srun=False)
@@ -78,7 +78,7 @@ def spack_install_and_test(spec: str,
     if spec.startswith('py-'):
         devirtualize_env()
 
-    log_with_spack('spack spec {spec}'
+    log_with_spack(f'spack spec {spec}'
         'system_test',
         log_filename,
         srun=False)


### PR DESCRIPTION
Simplifies problem hunting, when a spec concretizes differently in a user's spack instance and Jenkins' spack instance. This normally happens when users have preinstalled packages they are unaware of.