### PR TITLE
Use tags for flexpart-opr and flexpart-fdb

### DIFF
--- a/repos/c2sm/packages/flexpart-fdb/package.py
+++ b/repos/c2sm/packages/flexpart-fdb/package.py
@@ -9,7 +9,7 @@ class FlexpartFdb(MakefilePackage):
     homepage = 'https://github.com/MeteoSwiss/flexpart'
     git = 'https://github.com/MeteoSwiss/flexpart.git'
 
-    version('fdb', branch='fdb')
+    version('fdb', tag='10.4.3_fdb')
 
     variant('mch', default=False)
 

--- a/repos/c2sm/packages/flexpart-opr/package.py
+++ b/repos/c2sm/packages/flexpart-opr/package.py
@@ -13,7 +13,7 @@ class FlexpartOpr(Package):
     homepage = 'https://github.com/MeteoSwiss-APN/flexpart-opr'
     git = 'ssh://git@github.com/MeteoSwiss-APN/flexpart-opr.git'
 
-    version('fdb', branch='fdb')
+    version('fdb', tag='0.0_fdb')
 
     def install(self, spec, prefix):
         mkdir(prefix.flexpartOpr)


### PR DESCRIPTION
Replaces use of branches as reported here https://github.com/C2SM/spack-c2sm/issues/854