### PR TITLE
[py-icon4py,py-gt4py] Remove unused versions

### DIFF
--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -16,7 +16,6 @@ class PyGt4py(PythonPackage):
     url = "git@github.com:GridTools/gt4py.git"
 
     version('main', branch='main', git=url)
-    version('1.0.1.1', tag='icon4py_20230413', git=url)
     version('1.0.1.1b', tag='icon4py_20230530', git=url)
     version('1.0.1.6', tag='icon4py_20231124', git=url)
 

--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -18,10 +18,6 @@ class PyGt4py(PythonPackage):
     version('main', branch='main', git=url)
     version('1.0.1.1', tag='icon4py_20230413', git=url)
     version('1.0.1.1b', tag='icon4py_20230530', git=url)
-    version('1.0.1.2', tag='icon4py_20230621', git=url)
-    version('1.0.1.3', tag='icon4py_20230817', git=url)
-    version('1.0.1.4', tag='icon4py_20230926', git=url)
-    version('1.0.1.5', tag='icon4py_20231027', git=url)
     version('1.0.1.6', tag='icon4py_20231124', git=url)
 
     maintainers = ['samkellerhals']

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -26,12 +26,7 @@ class PyIcon4py(PythonPackage):
     version('main', branch='main', git=git)
     version('0.0.3', tag='v0.0.3', git=git)
     version('0.0.3.1', tag='v0.0.3.1', git=git)
-    version('0.0.4', tag='v0.0.4', git=git)
-    version('0.0.5', tag='v0.0.5', git=git)
-    version('0.0.6', tag='v0.0.6', git=git)
-    version('0.0.7', tag='v0.0.7', git=git)
-    version('0.0.9', tag='v0.0.9',
-            git=git)  #v0.0.8 is skipped due to extraneous dependencies
+    version('0.0.9', tag='v0.0.9', git=git)
 
     depends_on('py-wheel', type='build')
     depends_on('py-setuptools', type='build')
@@ -82,27 +77,12 @@ class PyIcon4py(PythonPackage):
                 'utils':
                 'liskov'  #utils will eventually map to parent directory of liskov
             },
-            ver('=0.0.4'): {
-                'atm_dyn_iconam': 'atm_dyn_iconam',
-                'tools': 'icon4pytools'
-            },
-            ver('=0.0.5'): {
-                'atm_dyn_iconam': 'atm_dyn_iconam',
-                'tools': 'icon4pytools'
-            },
-            ver('=0.0.6'): {
-                'atm_dyn_iconam': 'dycore',
-                'tools': 'icon4pytools'
-            },
-            ver('=0.0.7'): {
-                'atm_dyn_iconam': 'dycore',
-                'tools': 'icon4pytools'
-            },
-            ver('=0.0.8'): {
+            ver('=0.0.9'): {
                 'atm_dyn_iconam': 'dycore',
                 'tools': 'icon4pytools',
                 'diffusion': 'diffusion/stencils',
                 'interpolation': 'interpolation/stencils',
+                'advection': 'advection',
             },
             ver('=main'): {
                 'atm_dyn_iconam': 'dycore',
@@ -168,12 +148,6 @@ class PythonPipBuilder(PythonPipBuilder):
             build_dirs = [
                 'common', 'pyutils', 'testutils', 'liskov', 'atm_dyn_iconam'
             ]
-        elif self.spec.version == ver('=0.0.4') or self.spec.version == ver(
-                '=0.0.5'):
-            build_dirs = ['common', 'atm_dyn_iconam', 'tools']
-        elif self.spec.version == ver('=0.0.6') or self.spec.version == ver(
-                '=0.0.7'):
-            build_dirs = ['tools', 'model/atmosphere/dycore', 'model/common/']
         else:
             build_dirs = [
                 'tools', 'model/atmosphere/dycore',

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -66,11 +66,6 @@ class PyIcon4py(PythonPackage):
         version = self.spec.version
 
         folder_mapping = {
-            ver('=0.0.3'): {
-                'atm_dyn_iconam': 'atm_dyn_iconam',
-                'utils':
-                'liskov'  #utils will eventually map to parent directory of liskov
-            },
             ver('=0.0.3.1'): {
                 'atm_dyn_iconam': 'atm_dyn_iconam',
                 'utils':
@@ -142,8 +137,7 @@ class PythonPipBuilder(PythonPipBuilder):
 
         pip = inspect.getmodule(pkg).pip
 
-        if self.spec.version == ver('=0.0.3') or self.spec.version == ver(
-                '=0.0.3.1'):
+        if self.spec.version == ver('=0.0.3.1'):
             build_dirs = [
                 'common', 'pyutils', 'testutils', 'liskov', 'atm_dyn_iconam'
             ]

--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -24,7 +24,6 @@ class PyIcon4py(PythonPackage):
     maintainers = ['agopal', 'samkellerhals']
 
     version('main', branch='main', git=git)
-    version('0.0.3', tag='v0.0.3', git=git)
     version('0.0.3.1', tag='v0.0.3.1', git=git)
     version('0.0.9', tag='v0.0.9', git=git)
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -408,9 +408,9 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_exclaim_test_gpu_dsl(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/latest/daint_dsl_nvhpc',
+            'config/cscs/spack/v0.20.1.2/daint_dsl_nvhpc',
             'git@github.com:C2SM/icon-exclaim.git',
-            'icon-dsl',
+            'new_tag', # will change back after new tag is released
             'icon',
             build_on_login_node=True)
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -408,9 +408,9 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_exclaim_test_gpu_dsl(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.7/daint_dsl_nvhpc',
-            'git@github.com:C2SM/icon.git',
-            'ci_dsl',
+            'config/cscs/spack/latest/daint_dsl_nvhpc',
+            'git@github.com:C2SM/icon-exclaim.git',
+            'icon-dsl',
             'icon',
             build_on_login_node=True)
 
@@ -621,20 +621,6 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_0_1_1b(self):
         spack_install_and_test('py-gt4py @1.0.1.1b')
 
-    def test_install_version_1_0_1_2(self):
-        spack_install_and_test('py-gt4py @1.0.1.2')
-
-    @pytest.mark.no_daint  # fails with ModuleNotFoundError: No module named 'dace'
-    @pytest.mark.no_balfrin  # fails with ModuleNotFoundError: No module named 'dace'
-    def test_install_version_1_0_1_3(self):
-        spack_install_and_test('py-gt4py @1.0.1.3')
-
-    def test_install_version_1_0_1_4(self):
-        spack_install_and_test('py-gt4py @1.0.1.4')
-
-    def test_install_version_1_0_1_5(self):
-        spack_install_and_test('py-gt4py @1.0.1.5')
-
     def test_install_version_1_0_1_6(self):
         spack_install_and_test('py-gt4py @1.0.1.6')
 
@@ -651,19 +637,9 @@ class PyIcon4pyTest(unittest.TestCase):
     def test_install_version_0_0_3(self):
         spack_install_and_test('py-icon4py @ 0.0.3.1 %gcc ^py-gt4py@1.0.1.1b')
 
-    def test_install_version_0_0_5(self):
-        spack_install_and_test('py-icon4py @ 0.0.5 %gcc ^py-gt4py@1.0.1.1')
-
-    def test_install_version_0_0_6(self):
-        spack_install_and_test('py-icon4py @ 0.0.6 %gcc ^py-gt4py@1.0.1.2')
-
-    def test_install_version_0_0_7(self):
-        spack_install_and_test(
-            'py-icon4py @ 0.0.7 %gcc ^py-gt4py@1.0.1.3 ^python@3.10.4')
-
     def test_install_version_0_0_9(self):
         spack_install_and_test(
-            'py-icon4py @ 0.0.9 %gcc ^py-gt4py@1.0.1.6 ^python@3.10.4')
+            'py-icon4py @ 0.0.9 %gcc ^py-gt4py@1.0.1.6')
 
 
 class PyInflectionTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -410,7 +410,7 @@ class IconTest(unittest.TestCase):
         spack_env_dev_install_and_test(
             'config/cscs/spack/v0.20.1.2/daint_dsl_nvhpc',
             'git@github.com:C2SM/icon-exclaim.git',
-            'new_tag', # will change back after new tag is released
+            'new_tag',  # will change back after new tag is released
             'icon',
             build_on_login_node=True)
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -638,8 +638,7 @@ class PyIcon4pyTest(unittest.TestCase):
         spack_install_and_test('py-icon4py @ 0.0.3.1 %gcc ^py-gt4py@1.0.1.1b')
 
     def test_install_version_0_0_9(self):
-        spack_install_and_test(
-            'py-icon4py @ 0.0.9 %gcc ^py-gt4py@1.0.1.6')
+        spack_install_and_test('py-icon4py @ 0.0.9 %gcc ^py-gt4py@1.0.1.6')
 
 
 class PyInflectionTest(unittest.TestCase):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -634,7 +634,7 @@ class PyHatchlingTest(unittest.TestCase):
 @pytest.mark.no_tsa  # py-isort install fails with: No module named 'poetry'.
 class PyIcon4pyTest(unittest.TestCase):
 
-    def test_install_version_0_0_3(self):
+    def test_install_version_0_0_3_1(self):
         spack_install_and_test('py-icon4py @ 0.0.3.1 %gcc ^py-gt4py@1.0.1.1b')
 
     def test_install_version_0_0_9(self):


### PR DESCRIPTION
We're only preserving versions of icon4py and gt4py that the users will need via icon-dsl. So far only one tag of icon-dsl exists, and another tag is in progress.  So only two tags of icon4py and gt4py each are retained. 