### PR TITLE
Add acm-license variant for ICON

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -91,9 +91,11 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('art',
             default=False,
             description='Enable the aerosols and reactive trace component ART')
-    variant('acm-license',
-            default=False,
-            description='Enable code parts that require accepting the ACM Software License')
+    variant(
+        'acm-license',
+        default=False,
+        description=
+        'Enable code parts that require accepting the ACM Software License')
 
     # Infrastructural Features:
     variant('mpi',

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -91,6 +91,9 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('art',
             default=False,
             description='Enable the aerosols and reactive trace component ART')
+    variant('acm-license',
+            default=False,
+            description='Enable code parts that require accepting the ACM Software License')
 
     # Infrastructural Features:
     variant('mpi',
@@ -305,6 +308,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 'dace',
                 'emvorado',
                 'art',
+                'acm-license',
                 'mpi',
                 'active-target-sync',
                 'async-io-rma',


### PR DESCRIPTION
Add variant acm-license for ICON
This is required for license reason and to be compatible with the latest ICON version