### PR TITLE
[ICON] add variant extra-configure-args

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -162,7 +162,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         default='none',
         multi=True,
         values=check_variant_extra_config_args,
-        description='Inject any configure argument not yet available as variant'
+        description='Inject any configure argument not yet available as variant\nUse this feature cautiously, as injecting non-variant configure arguments may potentially disrupt the build process'
     )
 
     # Optimization Features:

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -646,6 +646,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 # to be set through variant extra_config_args
                 self.validate_extra_config_args(x)
                 config_args.append(x)
+            tty.warn('You use variant extra-config-args. Injecting non-variant configure arguments may potentially disrupt the build process!')
 
         # Finalize the LIBS variable (we always put the real collected
         # libraries to the front):

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -646,7 +646,9 @@ class Icon(AutotoolsPackage, CudaPackage):
                 # to be set through variant extra_config_args
                 self.validate_extra_config_args(x)
                 config_args.append(x)
-            tty.warn('You use variant extra-config-args. Injecting non-variant configure arguments may potentially disrupt the build process!')
+            tty.warn(
+                'You use variant extra-config-args. Injecting non-variant configure arguments may potentially disrupt the build process!'
+            )
 
         # Finalize the LIBS variable (we always put the real collected
         # libraries to the front):

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -26,13 +26,13 @@ def check_variant_fcgroup(fcgroup):
         return False
 
 
-def check_variant_extra_configure_arg(extra_configure_arg):
+def check_variant_extra_config_args(extra_config_arg):
     pattern = re.compile(r'--(enable|disable)-\S+')
-    if pattern.match(extra_configure_arg) or extra_configure_arg == 'none':
+    if pattern.match(extra_config_arg) or extra_config_arg == 'none':
         return True
     else:
         tty.warn(
-            f'The value "{extra_configure_arg}" for the extra_configure_args variant must follow the format "--enable-arg" or "--disable-arg"'
+            f'The value "{extra_config_arg}" for the extra_config_args variant must follow the format "--enable-arg" or "--disable-arg"'
         )
         return False
 
@@ -161,7 +161,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         'extra-config-args',
         default='none',
         multi=True,
-        values=check_variant_extra_configure_arg,
+        values=check_variant_extra_config_args,
         description='Inject any configure argument not yet available as variant'
     )
 

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -25,13 +25,17 @@ def check_variant_fcgroup(fcgroup):
         tty.warn('Variant fcgroup needs format GROUP.files.flag')
         return False
 
+
 def check_variant_extra_configure_arg(extra_configure_arg):
     pattern = re.compile(r'--(enable|disable)-\S+')
     if pattern.match(extra_configure_arg) or extra_configure_arg == 'none':
         return True
     else:
-        tty.warn(f'The value "{extra_configure_arg}" for the extra_configure_args variant must follow the format "--enable-arg" or "--disable-arg"')
+        tty.warn(
+            f'The value "{extra_configure_arg}" for the extra_configure_args variant must follow the format "--enable-arg" or "--disable-arg"'
+        )
         return False
+
 
 class Icon(AutotoolsPackage, CudaPackage):
     """Icosahedral Nonhydrostatic Weather and Climate Model."""
@@ -158,8 +162,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         default='none',
         multi=True,
         values=check_variant_extra_configure_arg,
-        description=
-        'Inject any configure argument not yet available as variant'
+        description='Inject any configure argument not yet available as variant'
     )
 
     # Optimization Features:
@@ -639,7 +642,6 @@ class Icon(AutotoolsPackage, CudaPackage):
         if extra_config_args != ('none', ):
             for x in extra_config_args:
                 config_args.append(x)
-
 
         # Finalize the LIBS variable (we always put the real collected
         # libraries to the front):

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -162,7 +162,8 @@ class Icon(AutotoolsPackage, CudaPackage):
         default='none',
         multi=True,
         values=check_variant_extra_config_args,
-        description='Inject any configure argument not yet available as variant\nUse this feature cautiously, as injecting non-variant configure arguments may potentially disrupt the build process'
+        description=
+        'Inject any configure argument not yet available as variant\nUse this feature cautiously, as injecting non-variant configure arguments may potentially disrupt the build process'
     )
 
     # Optimization Features:
@@ -684,7 +685,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             var[f'ICON_{name}_FCFLAGS'] = [flag]
         return var
 
-    def strip_variant_prefix(self,variant_string):
+    def strip_variant_prefix(self, variant_string):
         prefixes = ["--enable-", "--disable-"]
 
         for prefix in prefixes:
@@ -692,13 +693,14 @@ class Icon(AutotoolsPackage, CudaPackage):
                 return variant_string[len(prefix):]
 
         raise ValueError
-    
-    def validate_extra_config_args(self,arg):
+
+    def validate_extra_config_args(self, arg):
         variant_from_arg = self.strip_variant_prefix(arg)
         if variant_from_arg in self.spec.variants:
-            raise error.SpecError(f'The value "{arg}" for the extra_config_args variant conflicts '
-                                      f'with the existing variant {variant_from_arg}. Set this variant instead.')
-
+            raise error.SpecError(
+                f'The value "{arg}" for the extra_config_args variant conflicts '
+                f'with the existing variant {variant_from_arg}. Set this variant instead.'
+            )
 
     @run_after('configure')
     def adjust_rttov_macro(self):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -309,7 +309,7 @@ class SpecTest(unittest.TestCase):
         spack_spec('icon serialization=create claw=std')
         spack_spec('icon fcgroup=DACE.externals/dace_icon.-O1')
         spack_spec(
-            'icon extra_configure_args=--disable-new_feature,--enable-old_config_arg'
+            'icon extra_config_args=--disable-new_feature,--enable-old_config_arg'
         )
 
     def test_icon_ham(self):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -308,6 +308,7 @@ class SpecTest(unittest.TestCase):
         spack_spec('icon')
         spack_spec('icon serialization=create claw=std')
         spack_spec('icon fcgroup=DACE.externals/dace_icon.-O1')
+        spack_spec('icon extra_configure_args=--disable-new_feature,--enable-old_config_arg')
 
     def test_icon_ham(self):
         spack_spec('icon-ham')

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -309,7 +309,7 @@ class SpecTest(unittest.TestCase):
         spack_spec('icon serialization=create claw=std')
         spack_spec('icon fcgroup=DACE.externals/dace_icon.-O1')
         spack_spec(
-            'icon extra_config_args=--disable-new_feature,--enable-old_config_arg'
+            'icon extra-config-args=--disable-new_feature,--enable-old_config_arg'
         )
 
     def test_icon_ham(self):

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -308,7 +308,9 @@ class SpecTest(unittest.TestCase):
         spack_spec('icon')
         spack_spec('icon serialization=create claw=std')
         spack_spec('icon fcgroup=DACE.externals/dace_icon.-O1')
-        spack_spec('icon extra_configure_args=--disable-new_feature,--enable-old_config_arg')
+        spack_spec(
+            'icon extra_configure_args=--disable-new_feature,--enable-old_config_arg'
+        )
 
     def test_icon_ham(self):
         spack_spec('icon-ham')


### PR DESCRIPTION
Multi-value variant to inject any configure-argument not yet available as variant.
Ensure that format is either "--enable-arg" or "--disable-arg".

Solves https://github.com/C2SM/spack-c2sm/issues/890

