### PR TITLE
[py-gt4py] Adding new gt4py v1.0.1.7

### DIFF
--- a/repos/c2sm/packages/py-gt4py/package.py
+++ b/repos/c2sm/packages/py-gt4py/package.py
@@ -18,6 +18,7 @@ class PyGt4py(PythonPackage):
     version('main', branch='main', git=url)
     version('1.0.1.1b', tag='icon4py_20230530', git=url)
     version('1.0.1.6', tag='icon4py_20231124', git=url)
+    version('1.0.1.7', tag='icon4py_20240119', git=url)
 
     maintainers = ['samkellerhals']
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -622,6 +622,9 @@ class PyGt4pyTest(unittest.TestCase):
     def test_install_version_1_0_1_6(self):
         spack_install_and_test('py-gt4py @1.0.1.6')
 
+    def test_install_version_1_0_1_7(self):
+        spack_install_and_test('py-gt4py @1.0.1.7')
+
 
 class PyHatchlingTest(unittest.TestCase):
 


### PR DESCRIPTION
Need this version for the jenkins stable-gt4py tests for latest icon4py. A new icon4py tag will follow. 