### PR TITLE
Add makedepf90 package for flexpart-cosmo

### DIFF
--- a/repos/c2sm/packages/flexpart-cosmo/package.py
+++ b/repos/c2sm/packages/flexpart-cosmo/package.py
@@ -21,6 +21,7 @@ class FlexpartCosmo(MakefilePackage):
 
     depends_on('eccodes +fortran')
     depends_on('netcdf-fortran')
+    depends_on('makedepf90')
 
     conflicts('%gcc@:10')
     conflicts('%nvhpc')

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install makedepf
+#
+# You can edit this file again by typing:
+#
+#     spack edit makedepf
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class Makedepf90(Package):
+    """ Makedepf90 is a program for automatic creation of
+        Makefile-style dependency lists for Fortran source code."""
+
+    homepage = "https://salsa.debian.org/science-team/makedepf90.git"
+    url = "https://salsa.debian.org/science-team/makedepf90.git"
+
+    maintainers("mjaehn")
+
+    version('3.0.1', git='https://salsa.debian.org/science-team/makedepf90.git', branch='debian/3.0.1-1')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+
+    def install(self, spec, prefix):
+        # Run the configure script
+        configure = Executable('./configure')
+        configure('--prefix={0}'.format(prefix), '--bindir={0}'.format(prefix.bin))
+
+        # Build and install
+        make()
+        make('install')

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install makedepf
-#
-# You can edit this file again by typing:
-#
-#     spack edit makedepf
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -17,7 +17,7 @@ class Makedepf90(AutotoolsPackage):
 
     maintainers("mjaehn")
 
-depends_on("gmake@4:")
+    depends_on("gmake@4:")
 
     version('3.0.1', branch='debian/3.0.1-1')
 

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -16,9 +16,7 @@ class Makedepf90(AutotoolsPackage):
 
     maintainers("mjaehn")
 
-    version('3.0.1',
-            git='https://salsa.debian.org/science-team/makedepf90.git',
-            branch='debian/3.0.1-1')
+    version('3.0.1', branch='debian/3.0.1-1')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -13,20 +13,11 @@ class Makedepf90(AutotoolsPackage):
     homepage = "https://salsa.debian.org/science-team/makedepf90"
     git = "https://salsa.debian.org/science-team/makedepf90.git"
     url = "https://salsa.debian.org/science-team/makedepf90/-/archive/debian/3.0.1-1/makedepf90-debian-3.0.1-1.tar.gz"
+    parallel = False  # Makefile is not thread-safe.
 
     maintainers("mjaehn")
 
     version('3.0.1', branch='debian/3.0.1-1')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-
-    def install(self, spec, prefix):
-        # Run the configure script
-        configure = Executable('./configure')
-        configure('--prefix={0}'.format(prefix),
-                  '--bindir={0}'.format(prefix.bin))
-
-        # Build and install
-        make()
-        make('install')
+    def configure_args(self):
+        return ['--bindir={0}'.format(self.prefix.bin)]

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -17,6 +17,8 @@ class Makedepf90(AutotoolsPackage):
 
     maintainers("mjaehn")
 
+depends_on("gmake@4:")
+
     version('3.0.1', branch='debian/3.0.1-1')
 
     def configure_args(self):

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -6,12 +6,12 @@
 from spack.package import *
 
 
-class Makedepf90(Package):
+class Makedepf90(AutotoolsPackage):
     """ Makedepf90 is a program for automatic creation of
         Makefile-style dependency lists for Fortran source code."""
 
-    homepage = "https://salsa.debian.org/science-team/makedepf90.git"
-    url = "https://salsa.debian.org/science-team/makedepf90.git"
+    git = "https://salsa.debian.org/science-team/makedepf90.git"
+    url = "https://salsa.debian.org/science-team/makedepf90/-/archive/debian/3.0.1-1/makedepf90-debian-3.0.1-1.tar.gz"
 
     maintainers("mjaehn")
 

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -10,6 +10,7 @@ class Makedepf90(AutotoolsPackage):
     """ Makedepf90 is a program for automatic creation of
         Makefile-style dependency lists for Fortran source code."""
 
+    homepage = "https://salsa.debian.org/science-team/makedepf90"
     git = "https://salsa.debian.org/science-team/makedepf90.git"
     url = "https://salsa.debian.org/science-team/makedepf90/-/archive/debian/3.0.1-1/makedepf90-debian-3.0.1-1.tar.gz"
 

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -115,6 +115,9 @@ class InfoTest(unittest.TestCase):
     def test_libxml2(self):
         spack_info('libxml2')
 
+    def test_makedepf90(self):
+        spack_info('makedepf90')
+
     def test_nvidia_blas(self):
         spack_info('nvidia-blas')
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -490,6 +490,11 @@ class LibGrib1Test(unittest.TestCase):
     def test_install_version_22_01_2020(self):
         spack_install_and_test('libgrib1 @22-01-2020')
 
+class Makedepf90Test(unittest.TestCase):
+
+    def test_install(self):
+        spack_install_and_test('makedepf90 @3.0.1')
+
 
 @pytest.mark.no_balfrin  # Package is a workaround, only needed on Daint.
 @pytest.mark.no_tsa  # Package is a workaround, only needed on Daint.

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -494,7 +494,7 @@ class LibGrib1Test(unittest.TestCase):
 class Makedepf90Test(unittest.TestCase):
 
     def test_install(self):
-        spack_install_and_test('makedepf90 @3.0.1')
+        spack_install('makedepf90 @3.0.1')
 
 
 @pytest.mark.no_balfrin  # Package is a workaround, only needed on Daint.

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -491,7 +491,6 @@ class LibGrib1Test(unittest.TestCase):
         spack_install_and_test('libgrib1 @22-01-2020')
 
 
-@pytest.mark.no_tsa  # No one uses spack for flexpart-cosmo on Tsa
 class Makedepf90Test(unittest.TestCase):
 
     def test_install(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -490,6 +490,7 @@ class LibGrib1Test(unittest.TestCase):
     def test_install_version_22_01_2020(self):
         spack_install_and_test('libgrib1 @22-01-2020')
 
+
 class Makedepf90Test(unittest.TestCase):
 
     def test_install(self):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -491,6 +491,7 @@ class LibGrib1Test(unittest.TestCase):
         spack_install_and_test('libgrib1 @22-01-2020')
 
 
+@pytest.mark.no_tsa  # No one uses spack for flexpart-cosmo on Tsa
 class Makedepf90Test(unittest.TestCase):
 
     def test_install(self):


### PR DESCRIPTION
Fixes https://github.com/C2SM/spack-c2sm/issues/889

@pirmink @ayanu 
I added the `makedepf90` package, which is now a dependency of `flexpart-cosmo`.