### PR TITLE
Makedep90 add dependency autoconf

### DIFF
--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -18,6 +18,7 @@ class Makedepf90(AutotoolsPackage):
     maintainers("mjaehn")
 
     depends_on("gmake@4:")
+    depends_on("autoconf")
 
     version('3.0.1', branch='debian/3.0.1-1')
 

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Makedepf90(AutoreconfPackageTemplate):
+class Makedepf90(AutoreconfPackage):
     """ Makedepf90 is a program for automatic creation of
         Makefile-style dependency lists for Fortran source code."""
 

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Makedepf90(AutoreconfPackage):
+class Makedepf90(AutotoolsPackage):
     """ Makedepf90 is a program for automatic creation of
         Makefile-style dependency lists for Fortran source code."""
 
@@ -18,8 +18,15 @@ class Makedepf90(AutoreconfPackage):
     maintainers("mjaehn")
 
     depends_on("gmake@4:")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
 
     version('3.0.1', branch='debian/3.0.1-1')
 
     def configure_args(self):
         return ['--bindir={0}'.format(self.prefix.bin)]
+
+    def autoreconf(self, spec, prefix):
+        autoreconf("--install", "--verbose", "--force")

--- a/repos/c2sm/packages/makedepf90/package.py
+++ b/repos/c2sm/packages/makedepf90/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Makedepf90(AutotoolsPackage):
+class Makedepf90(AutoreconfPackageTemplate):
     """ Makedepf90 is a program for automatic creation of
         Makefile-style dependency lists for Fortran source code."""
 
@@ -18,7 +18,6 @@ class Makedepf90(AutotoolsPackage):
     maintainers("mjaehn")
 
     depends_on("gmake@4:")
-    depends_on("autoconf")
 
     version('3.0.1', branch='debian/3.0.1-1')
 


### PR DESCRIPTION
Required during configure : https://salsa.debian.org/science-team/makedepf90/-/blob/debian/3.0.1-1/Makefile.def?ref_type=tags#L137