### PR TITLE
[py-icon4py] Fixing folder mapping for v0.0.10

### DIFF
--- a/repos/c2sm/packages/py-icon4py/package.py
+++ b/repos/c2sm/packages/py-icon4py/package.py
@@ -79,6 +79,13 @@ class PyIcon4py(PythonPackage):
                 'interpolation': 'interpolation/stencils',
                 'advection': 'advection',
             },
+            ver('=0.0.10'): {
+                'atm_dyn_iconam': 'dycore',
+                'tools': 'icon4pytools',
+                'diffusion': 'diffusion/stencils',
+                'interpolation': 'interpolation/stencils',
+                'advection': 'advection',
+            },
             ver('=main'): {
                 'atm_dyn_iconam': 'dycore',
                 'tools': 'icon4pytools',


### PR DESCRIPTION
Forgot to add this folder mapping for icon4py tag 0.0.10 when it was originally added. Only showed an error when we tried to build icon-dsl with this version of icon4py. 