### PR TITLE
Enabling support for ComIn in ICON

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -165,6 +165,10 @@ class Icon(AutotoolsPackage, CudaPackage):
         description=
         'Inject any configure argument not yet available as variant\nUse this feature cautiously, as injecting non-variant configure arguments may potentially disrupt the build process'
     )
+    variant('comin',
+            default=False,
+            description='Enable usage of ComIn toolbox '
+            'for building plugins.')
 
     # Optimization Features:
     variant('loop-exchange', default=True, description='Enable loop exchange')
@@ -360,6 +364,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 'nccl',
                 'cuda-graphs',
                 'silent-rules',
+                'comin',
         ]:
             config_args += self.enable_or_disable(x)
 


### PR DESCRIPTION
A new variant 'comin' was created to allow the enabling of ComIn in icon (default is `False`).

--> Use `+comin` to enable ComIn in the spack recipe.