### PR TITLE
[icon] Update to version 2024.01

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -40,7 +40,7 @@ def check_variant_extra_config_args(extra_config_arg):
 class Icon(AutotoolsPackage, CudaPackage):
     """Icosahedral Nonhydrostatic Weather and Climate Model."""
 
-     homepage = "https://www.icon-model.org"
+    homepage = "https://www.icon-model.org"
     url = "https://gitlab.dkrz.de/icon/icon-model/-/archive/icon-2024.01-public/icon-model-icon-2024.01-public.tar.gz"
     git = 'git@gitlab.dkrz.de:icon/icon.git'
 

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -47,7 +47,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     maintainers = ['jonasjucker', 'dominichofer']
 
     version('develop', submodules=True)
-    version("2024.01", sha256="d9408fdd6a9ebf5990298e9a09c826e8c15b1e79b45be228f7a5670a3091a613", submodules=True)
+    version("2024.01", tag="icon-2024.01", submodules=True)
     version('exclaim-master',
             branch='master',
             git='git@github.com:C2SM/icon-exclaim.git',
@@ -102,7 +102,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('art',
             default=False,
             description='Enable the aerosols and reactive trace component ART')
-    variant('art-gpl'
+    variant('art-gpl',
             default=False,
             description='Enable GPL-licensed code parts of the ART component'
             )

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -251,7 +251,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     depends_on('rttov~openmp', when='~openmp+rttov')
 
     for x in serialization_values:
-        depends_on('serialbox+fortran~shared',
+        depends_on('serialbox+fortran',
                    when='serialization={0}'.format(x))
 
     depends_on('libcdi-pio+fortran+netcdf', when='+cdi-pio')
@@ -513,12 +513,9 @@ class Icon(AutotoolsPackage, CudaPackage):
         else:
             args.extend([
                 '--enable-serialization={0}'.format(serialization),
-                '--enable-explicit-fpp',
                 'SB2PP={0}'.format(self.spec['serialbox'].pp_ser)
             ])
             libs += self.spec['serialbox:fortran'].libs
-            # static libs from serialbox need libstdc++ to link
-            flags['LIBS'].extend(['-lstdc++ -lstdc++fs'])
 
         if '+cdi-pio' in self.spec:
             libs += self.spec['libcdi-pio:fortran'].libs

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -47,7 +47,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     maintainers = ['jonasjucker', 'dominichofer']
 
     version('develop', submodules=True)
-    version("2024.01", tag="icon-2024.01", submodules=True)
+    version("2024.01-1", tag="icon-2024.01-1", submodules=True)
     version('exclaim-master',
             branch='master',
             git='git@github.com:C2SM/icon-exclaim.git',

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -245,8 +245,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     depends_on('rttov~openmp', when='~openmp+rttov')
 
     for x in serialization_values:
-        depends_on('serialbox+fortran',
-                   when='serialization={0}'.format(x))
+        depends_on('serialbox+fortran', when='serialization={0}'.format(x))
 
     depends_on('libcdi-pio+fortran+netcdf', when='+cdi-pio')
     depends_on('libcdi-pio grib2=eccodes', when='+cdi-pio+grib2')

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -40,14 +40,14 @@ def check_variant_extra_config_args(extra_config_arg):
 class Icon(AutotoolsPackage, CudaPackage):
     """Icosahedral Nonhydrostatic Weather and Climate Model."""
 
-    homepage = 'https://code.mpimet.mpg.de/projects/iconpublic'
-    url = 'https://gitlab.dkrz.de/icon/icon/-/archive/icon-2.6.6/icon-icon-2.6.6.tar.gz'
+     homepage = "https://www.icon-model.org"
+    url = "https://gitlab.dkrz.de/icon/icon-model/-/archive/icon-2024.01-public/icon-model-icon-2024.01-public.tar.gz"
     git = 'git@gitlab.dkrz.de:icon/icon.git'
 
     maintainers = ['jonasjucker', 'dominichofer']
 
     version('develop', submodules=True)
-    version('2.6.6', tag='icon-2.6.6', submodules=True)
+    version("2024.01", sha256="d9408fdd6a9ebf5990298e9a09c826e8c15b1e79b45be228f7a5670a3091a613", submodules=True)
     version('exclaim-master',
             branch='master',
             git='git@github.com:C2SM/icon-exclaim.git',
@@ -68,9 +68,6 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('atmo',
             default=True,
             description='Enable the atmosphere component')
-    variant('edmf',
-            default=True,
-            description='Enable the EDMF turbulence component')
     variant('les',
             default=True,
             description='Enable the Large-Eddy Simulation component')
@@ -84,6 +81,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             description='Enable the surface wave component')
     variant('coupling', default=True, description='Enable the coupling')
     variant('aes', default=True, description='Enable the AES physics package')
+    variant('nwp', default=True, description='Enable the NWP physics package')
     variant('ecrad',
             default=False,
             description='Enable usage of the ECMWF radiation scheme')
@@ -104,6 +102,14 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('art',
             default=False,
             description='Enable the aerosols and reactive trace component ART')
+    variant('art-gpl'
+            default=False,
+            description='Enable GPL-licensed code parts of the ART component'
+            )
+    variant('comin',
+            default=False,
+            description='Enable the ICON community interfaces'
+            )
     variant(
         'acm-license',
         default=False,
@@ -189,7 +195,7 @@ class Icon(AutotoolsPackage, CudaPackage):
     variant('cuda-graphs',
             default=False,
             description=
-            'Enable CUDA graphs. Warning! This is an experimental feature')
+            'Enable CUDA graphs.')
     variant(
         'fcgroup',
         default='none',
@@ -333,7 +339,6 @@ class Icon(AutotoolsPackage, CudaPackage):
 
         for x in [
                 'atmo',
-                'edmf',
                 'les',
                 'upatmo',
                 'ocean',
@@ -341,12 +346,15 @@ class Icon(AutotoolsPackage, CudaPackage):
                 'waves',
                 'coupling',
                 'aes',
+                'nwp',
                 'ecrad',
                 'rte-rrtmgp',
                 'rttov',
                 'dace',
                 'emvorado',
                 'art',
+                'art-gpl',
+                'comin'
                 'acm-license',
                 'mpi',
                 'active-target-sync',

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -104,12 +104,10 @@ class Icon(AutotoolsPackage, CudaPackage):
             description='Enable the aerosols and reactive trace component ART')
     variant('art-gpl',
             default=False,
-            description='Enable GPL-licensed code parts of the ART component'
-            )
+            description='Enable GPL-licensed code parts of the ART component')
     variant('comin',
             default=False,
-            description='Enable the ICON community interfaces'
-            )
+            description='Enable the ICON community interfaces')
     variant(
         'acm-license',
         default=False,
@@ -192,10 +190,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         description=
         'Enable PGI/NVIDIA cross-file function inlining via an inline library')
     variant('nccl', default=False, description='Enable NCCL for communication')
-    variant('cuda-graphs',
-            default=False,
-            description=
-            'Enable CUDA graphs.')
+    variant('cuda-graphs', default=False, description='Enable CUDA graphs.')
     variant(
         'fcgroup',
         default='none',
@@ -412,12 +407,10 @@ class Icon(AutotoolsPackage, CudaPackage):
             fc_version = self.compiler.version
             if fc_version >= ver(10):
                 flags['ICON_FCFLAGS'].append('-fallow-argument-mismatch')
-                flags['ICON_OCEAN_FCFLAGS'].append(
-                    '-fallow-argument-mismatch')
+                flags['ICON_OCEAN_FCFLAGS'].append('-fallow-argument-mismatch')
                 if '+ecrad' in self.spec:
                     # For externals/ecrad/ifsaux/random_numbers_mix.F90:
-                    flags['ICON_ECRAD_FCFLAGS'].append(
-                        '-fallow-invalid-boz')
+                    flags['ICON_ECRAD_FCFLAGS'].append('-fallow-invalid-boz')
         elif self.compiler.name == 'intel':
             flags['CFLAGS'].extend(
                 ['-g', '-gdwarf-4', '-O3', '-qno-opt-dynamic-align', '-ftz'])
@@ -638,8 +631,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                     'liskov does not support fusing just yet')
 
             flags['LOC_GT4PY'].append(self.spec['py-gt4py'].prefix)
-            flags['LOC_ICON4PY_BIN'].append(
-                self.spec['py-icon4py'].prefix)
+            flags['LOC_ICON4PY_BIN'].append(self.spec['py-icon4py'].prefix)
 
             flags['LOC_ICON4PY_ATM_DYN_ICONAM'].append(
                 self.spec['py-icon4py:atm_dyn_iconam'].headers.directories[0])
@@ -693,8 +685,7 @@ class Icon(AutotoolsPackage, CudaPackage):
         ])
 
         args.extend([
-            '{0}={1}'.format(var, ' '.join(val))
-            for var, val in flags.items()
+            '{0}={1}'.format(var, ' '.join(val)) for var, val in flags.items()
         ])
 
         return args

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -333,8 +333,8 @@ class Icon(AutotoolsPackage, CudaPackage):
             env.set("BOOST_ROOT", self.spec['boost'].prefix)
 
     def configure_args(self):
-        config_args = ['--disable-rpaths']
-        config_vars = defaultdict(list)
+        args = ['--disable-rpaths']
+        flags = defaultdict(list)
         libs = LibraryList([])
 
         for x in [
@@ -376,19 +376,19 @@ class Icon(AutotoolsPackage, CudaPackage):
                 'silent-rules',
                 'comin',
         ]:
-            config_args += self.enable_or_disable(x)
+            args += self.enable_or_disable(x)
 
         if '+cdi-pio' in self.spec:
-            config_args.extend([
+            args.extend([
                 '--enable-cdi-pio', '--with-external-cdi',
                 '--with-external-yaxt'
             ])
 
         if self.compiler.name == 'gcc':
-            config_vars['CFLAGS'].append('-g')
-            config_vars['ICON_CFLAGS'].append('-O3')
-            config_vars['ICON_BUNDLED_CFLAGS'].append('-O2')
-            config_vars['FCFLAGS'].extend([
+            flags['CFLAGS'].append('-g')
+            flags['ICON_CFLAGS'].append('-O3')
+            flags['ICON_BUNDLED_CFLAGS'].append('-O2')
+            flags['FCFLAGS'].extend([
                 '-g',
                 '-fmodule-private',
                 '-fimplicit-none',
@@ -401,48 +401,48 @@ class Icon(AutotoolsPackage, CudaPackage):
                 '-Wno-surprising',
                 '-fall-intrinsics',
             ])
-            config_vars['ICON_FCFLAGS'].extend([
+            flags['ICON_FCFLAGS'].extend([
                 '-O2', '-fbacktrace', '-fbounds-check',
                 '-fstack-protector-all', '-finit-real=nan',
                 '-finit-integer=-2147483648', '-finit-character=127'
             ])
-            config_vars['ICON_OCEAN_FCFLAGS'].append('-O3')
+            flags['ICON_OCEAN_FCFLAGS'].append('-O3')
 
             # Version-specific workarounds:
             fc_version = self.compiler.version
             if fc_version >= ver(10):
-                config_vars['ICON_FCFLAGS'].append('-fallow-argument-mismatch')
-                config_vars['ICON_OCEAN_FCFLAGS'].append(
+                flags['ICON_FCFLAGS'].append('-fallow-argument-mismatch')
+                flags['ICON_OCEAN_FCFLAGS'].append(
                     '-fallow-argument-mismatch')
                 if '+ecrad' in self.spec:
                     # For externals/ecrad/ifsaux/random_numbers_mix.F90:
-                    config_vars['ICON_ECRAD_FCFLAGS'].append(
+                    flags['ICON_ECRAD_FCFLAGS'].append(
                         '-fallow-invalid-boz')
         elif self.compiler.name == 'intel':
-            config_vars['CFLAGS'].extend(
+            flags['CFLAGS'].extend(
                 ['-g', '-gdwarf-4', '-O3', '-qno-opt-dynamic-align', '-ftz'])
-            config_vars['FCFLAGS'].extend(
+            flags['FCFLAGS'].extend(
                 ['-g', '-gdwarf-4', '-traceback', '-fp-model source'])
-            config_vars['ICON_FCFLAGS'].extend(
+            flags['ICON_FCFLAGS'].extend(
                 ['-O2', '-assume realloc_lhs', '-ftz'])
-            config_vars['ICON_OCEAN_FCFLAGS'].extend([
+            flags['ICON_OCEAN_FCFLAGS'].extend([
                 '-O3', '-assume norealloc_lhs', '-reentrancy threaded',
                 '-qopt-report-file=stdout', '-qopt-report=0',
                 '-qopt-report-phase=vec'
             ])
-            config_args.append('--enable-intel-consistency')
+            args.append('--enable-intel-consistency')
         elif self.compiler.name == 'nag':
-            config_vars['CFLAGS'].append('-g')
-            config_vars['ICON_CFLAGS'].append('-O3')
-            config_vars['ICON_BUNDLED_CFLAGS'].append('-O2')
-            config_vars['FCFLAGS'].extend([
+            flags['CFLAGS'].append('-g')
+            flags['ICON_CFLAGS'].append('-O3')
+            flags['ICON_BUNDLED_CFLAGS'].append('-O2')
+            flags['FCFLAGS'].extend([
                 '-g', '-Wc,-g', '-O0', '-colour', '-f2008', '-w=uep',
                 '-float-store', '-nan'
             ])
             if '~openmp' in self.spec:
                 # The -openmp option is incompatible with the -gline option:
-                config_vars['FCFLAGS'].append('-gline')
-            config_vars['ICON_FCFLAGS'].extend([
+                flags['FCFLAGS'].append('-gline')
+            flags['ICON_FCFLAGS'].extend([
                 '-Wc,-pipe',
                 '-Wc,--param,max-vartrack-size=200000000',
                 '-Wc,-mno-fma',
@@ -460,41 +460,41 @@ class Icon(AutotoolsPackage, CudaPackage):
                 '-C=pointer',
                 '-C=recursion'
             ])
-            config_vars['ICON_BUNDLED_FCFLAGS'] = []
+            flags['ICON_BUNDLED_FCFLAGS'] = []
         elif self.compiler.name in ['pgi', 'nvhpc']:
-            config_vars['CFLAGS'].extend(['-g', '-O2'])
-            config_vars['FCFLAGS'].extend(
+            flags['CFLAGS'].extend(['-g', '-O2'])
+            flags['FCFLAGS'].extend(
                 ['-g', '-O', '-Mrecursive', '-Mallocatable=03', '-Mbackslash'])
 
             if self.spec.variants['gpu'].value == 'openacc+cuda':
-                config_vars['FCFLAGS'].extend([
+                flags['FCFLAGS'].extend([
                     '-acc=verystrict', '-Minfo=accel,inline',
                     '-gpu=cc{0}'.format(
                         self.spec.variants['cuda_arch'].value[0])
                 ])
         elif self.compiler.name == 'cce':
-            config_vars['CFLAGS'].append('-g')
-            config_vars['ICON_CFLAGS'].append('-O3')
+            flags['CFLAGS'].append('-g')
+            flags['ICON_CFLAGS'].append('-O3')
             if self.spec.satisfies('%cce@13.0.0+coupling'):
                 # For externals/yac/tests/test_interpolation_method_conserv.c:
-                config_vars['ICON_YAC_CFLAGS'].append('-O2')
-            config_vars['FCFLAGS'].extend([
+                flags['ICON_YAC_CFLAGS'].append('-O2')
+            flags['FCFLAGS'].extend([
                 '-hadd_paren', '-r am', '-Ktrap=divz,ovf,inv',
                 '-hflex_mp=intolerant', '-hfp0', '-O0'
             ])
             if self.spec.variants['gpu'].value == 'openacc+cuda':
-                config_vars['FCFLAGS'].extend(['-hacc'])
+                flags['FCFLAGS'].extend(['-hacc'])
         elif self.compiler.name == 'aocc':
-            config_vars['CFLAGS'].extend(['-g', '-O2'])
-            config_vars['FCFLAGS'].extend(['-g', '-O2'])
+            flags['CFLAGS'].extend(['-g', '-O2'])
+            flags['FCFLAGS'].extend(['-g', '-O2'])
             if self.spec.satisfies('~cdi-pio+yaxt'):
                 # Enable the PGI/Cray (NO_2D_PARAM) workaround for the test
                 # suite of the bundled YAXT (apply also when not self.run_tests
                 # to make sure we get identical installations):
-                config_vars['ICON_YAXT_FCFLAGS'].append('-DNO_2D_PARAM')
+                flags['ICON_YAXT_FCFLAGS'].append('-DNO_2D_PARAM')
         else:
-            config_vars['CFLAGS'].extend(['-g', '-O2'])
-            config_vars['FCFLAGS'].extend(['-g', '-O2'])
+            flags['CFLAGS'].extend(['-g', '-O2'])
+            flags['FCFLAGS'].extend(['-g', '-O2'])
 
         if '+coupling' in self.spec or '+art' in self.spec:
             xml2_spec = self.spec['libxml2']
@@ -509,23 +509,23 @@ class Icon(AutotoolsPackage, CudaPackage):
                     d for d in xml2_headers.directories
                     if not is_system_path(d)
                 ]
-                config_vars['CPPFLAGS'].append(xml2_headers.include_flags)
+                flags['CPPFLAGS'].append(xml2_headers.include_flags)
 
         if '+coupling' in self.spec:
             libs += self.spec['libfyaml'].libs
 
         serialization = self.spec.variants['serialization'].value
         if serialization == 'none':
-            config_args.append('--disable-serialization')
+            args.append('--disable-serialization')
         else:
-            config_args.extend([
+            args.extend([
                 '--enable-serialization={0}'.format(serialization),
                 '--enable-explicit-fpp',
                 'SB2PP={0}'.format(self.spec['serialbox'].pp_ser)
             ])
             libs += self.spec['serialbox:fortran'].libs
             # static libs from serialbox need libstdc++ to link
-            config_vars['LIBS'].extend(['-lstdc++ -lstdc++fs'])
+            flags['LIBS'].extend(['-lstdc++ -lstdc++fs'])
 
         if '+cdi-pio' in self.spec:
             libs += self.spec['libcdi-pio:fortran'].libs
@@ -558,7 +558,7 @@ class Icon(AutotoolsPackage, CudaPackage):
             libs += self.spec['zlib'].libs
 
         if '+mpi' in self.spec:
-            config_args.extend([
+            args.extend([
                 'CC=' + self.spec['mpi'].mpicc,
                 'FC=' + self.spec['mpi'].mpifc,
                 # We cannot provide a universal value for MPI_LAUNCH, therefore
@@ -574,28 +574,28 @@ class Icon(AutotoolsPackage, CudaPackage):
         fcgroup = self.spec.variants['fcgroup'].value
         # ('none',) is the values spack assign if fcgroup is not set
         if fcgroup != ('none', ):
-            config_args.extend(self.fcgroup_to_config_arg())
-            config_vars.update(self.fcgroup_to_config_var())
+            args.extend(self.fcgroup_to_config_arg())
+            flags.update(self.fcgroup_to_config_var())
 
         claw = self.spec.variants['claw'].value
         if claw == 'none':
-            config_args.append('--disable-claw')
+            args.append('--disable-claw')
         else:
-            config_args.extend([
+            args.extend([
                 '--enable-claw={0}'.format(claw),
                 'CLAW={0}'.format(self.spec['claw'].prefix.bin.clawfc)
             ])
-            config_vars['CLAWFLAGS'].append(
+            flags['CLAWFLAGS'].append(
                 self.spec['netcdf-fortran'].headers.include_flags)
             if '+cdi-pio' in self.spec:
-                config_vars['CLAWFLAGS'].append(
+                flags['CLAWFLAGS'].append(
                     self.spec['libcdi-pio'].headers.include_flags)
 
         gpu = self.spec.variants['gpu'].value
         if gpu == 'no':
-            config_args.append('--disable-gpu')
+            args.append('--disable-gpu')
         else:
-            config_args.extend([
+            args.extend([
                 '--enable-gpu={0}'.format(gpu),
                 'NVCC={0}'.format(self.spec['cuda'].prefix.bin.nvcc)
             ])
@@ -606,65 +606,65 @@ class Icon(AutotoolsPackage, CudaPackage):
             cuda_host_compiler_stdcxx_libs = self.compiler.stdcxx_libs
 
             if 'none' in self.spec.variants['dsl'].value:
-                config_vars['NVCFLAGS'].extend(
+                flags['NVCFLAGS'].extend(
                     ['-ccbin {0}'.format(cuda_host_compiler)])
 
-            config_vars['NVCFLAGS'].extend([
+            flags['NVCFLAGS'].extend([
                 '-g', '-O3',
                 '-arch=sm_{0}'.format(self.spec.variants['cuda_arch'].value[0])
             ])
             # cuda_host_compiler_stdcxx_libs might contain compiler-specific
             # flags (i.e. not the linker -l<library> flags), therefore we put
             # the value to the config_flags directly.
-            config_vars['LIBS'].extend(cuda_host_compiler_stdcxx_libs)
+            flags['LIBS'].extend(cuda_host_compiler_stdcxx_libs)
 
         # Check for DSL variants and set corresponding Liskov options
         dsl = self.spec.variants['dsl'].value
         if dsl != ('none', ):
             if 'substitute' in dsl:
-                config_args.append('--enable-liskov=substitute')
+                args.append('--enable-liskov=substitute')
             elif 'verify' in dsl:
-                config_args.append('--enable-liskov=verify')
+                args.append('--enable-liskov=verify')
             elif 'serialize' in dsl:
                 raise error.UnsupportedPlatformError(
                     'serialize mode is not supported yet by icon-liskov')
 
             if 'lam' in dsl:
-                config_args.append('--enable-dsl-local')
+                args.append('--enable-dsl-local')
             if 'nvtx' in dsl:
-                config_args.append('--enable-nvtx')
+                args.append('--enable-nvtx')
             if 'fused' in dsl:
                 raise error.UnsupportedPlatformError(
                     'liskov does not support fusing just yet')
 
-            config_vars['LOC_GT4PY'].append(self.spec['py-gt4py'].prefix)
-            config_vars['LOC_ICON4PY_BIN'].append(
+            flags['LOC_GT4PY'].append(self.spec['py-gt4py'].prefix)
+            flags['LOC_ICON4PY_BIN'].append(
                 self.spec['py-icon4py'].prefix)
 
-            config_vars['LOC_ICON4PY_ATM_DYN_ICONAM'].append(
+            flags['LOC_ICON4PY_ATM_DYN_ICONAM'].append(
                 self.spec['py-icon4py:atm_dyn_iconam'].headers.directories[0])
 
             if self.spec['py-icon4py'].version < Version("0.0.4"):
-                config_vars['LOC_ICON4PY_UTILS'].append(
+                flags['LOC_ICON4PY_UTILS'].append(
                     os.path.dirname(
                         self.spec['py-icon4py:utils'].headers.directories[0]))
             else:
-                config_vars['LOC_ICON4PY_TOOLS'].append(
+                flags['LOC_ICON4PY_TOOLS'].append(
                     self.spec['py-icon4py:tools'].headers.directories[0])
                 if self.spec['py-icon4py'].version > Version("0.0.7"):
-                    config_vars['LOC_ICON4PY_DIFFUSION'].append(
+                    flags['LOC_ICON4PY_DIFFUSION'].append(
                         self.spec['py-icon4py:diffusion'].headers.
                         directories[0])
-                    config_vars['LOC_ICON4PY_INTERPOLATION'].append(
+                    flags['LOC_ICON4PY_INTERPOLATION'].append(
                         self.spec['py-icon4py:interpolation'].headers.
                         directories[0])
                 if self.spec['py-icon4py'].version > Version("0.0.8"):
-                    config_vars['LOC_ICON4PY_ADVECTION'].append(
+                    flags['LOC_ICON4PY_ADVECTION'].append(
                         self.spec['py-icon4py:advection'].headers.
                         directories[0])
-            config_vars['LOC_GRIDTOOLS'].append(
+            flags['LOC_GRIDTOOLS'].append(
                 self.spec['py-gridtools-cpp:data'].headers.directories[0])
-            config_vars['GT4PYNVCFLAGS'] = config_vars['NVCFLAGS']
+            flags['GT4PYNVCFLAGS'] = flags['NVCFLAGS']
 
         # add configure arguments not yet available as variant
         extra_config_args = self.spec.variants['extra-config-args'].value
@@ -673,31 +673,31 @@ class Icon(AutotoolsPackage, CudaPackage):
                 # prevent configure-args already available as variant
                 # to be set through variant extra_config_args
                 self.validate_extra_config_args(x)
-                config_args.append(x)
+                args.append(x)
             tty.warn(
                 'You use variant extra-config-args. Injecting non-variant configure arguments may potentially disrupt the build process!'
             )
 
         # Finalize the LIBS variable (we always put the real collected
         # libraries to the front):
-        config_vars['LIBS'].insert(0, libs.link_flags)
+        flags['LIBS'].insert(0, libs.link_flags)
 
         # Help the libtool scripts of the bundled libraries find the correct
         # paths to the external libraries. Specify the library search (-L) flags
         # in the reversed order
         # (see https://gitlab.dkrz.de/icon/icon#icon-dependencies):
         # and for non-system directories only:
-        config_vars['LDFLAGS'].extend([
+        flags['LDFLAGS'].extend([
             '-L{0}'.format(d) for d in reversed(libs.directories)
             if not is_system_path(d)
         ])
 
-        config_args.extend([
+        args.extend([
             '{0}={1}'.format(var, ' '.join(val))
-            for var, val in config_vars.items()
+            for var, val in flags.items()
         ])
 
-        return config_args
+        return args
 
     def fcgroup_to_config_arg(self):
         arg = []

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -62,7 +62,7 @@ class Icon(AutotoolsPackage, CudaPackage):
 
     # The variants' default follow those of ICON
     # as described here
-    # https://gitlab.dkrz.de/icon/icon/-/blob/icon-2.6.6/configure#L1457-1563
+    # https://gitlab.dkrz.de/icon/icon/-/blob/icon-2024.01/configure?ref_type=tags#L1492-1638
 
     # Model Features:
     variant('atmo',

--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -354,7 +354,7 @@ class Icon(AutotoolsPackage, CudaPackage):
                 'emvorado',
                 'art',
                 'art-gpl',
-                'comin'
+                'comin',
                 'acm-license',
                 'mpi',
                 'active-target-sync',

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -288,7 +288,7 @@ class SpecTest(unittest.TestCase):
 
     def test_icon(self):
         spack_spec('icon')
-        spack_spec('icon serialization=create claw=std')
+        spack_spec('icon serialization=create')
         spack_spec('icon fcgroup=DACE.externals/dace_icon.-O1')
         spack_spec(
             'icon extra-config-args=--disable-new_feature,--enable-old_config_arg'

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -333,11 +333,11 @@ class GridToolsTest(unittest.TestCase):
 class IconTest(unittest.TestCase):
 
     def test_install_2024_1_gcc(self):
-        spack_install_and_test('icon @2024.1 %gcc')
+        spack_install_and_test('icon @2024.1-1 %gcc')
 
     @pytest.mark.no_daint
     def test_install_2024_1_nvhpc(self):
-        spack_install_and_test('icon @2024.1 %nvhpc')
+        spack_install_and_test('icon @2024.1-1 %nvhpc')
 
     @pytest.mark.no_daint  # libxml2 %nvhpc fails to build
     def test_install_conditional_dependencies(self):
@@ -350,7 +350,7 @@ class IconTest(unittest.TestCase):
         # +mpi triggers mpi
         # claw=std triggers claw
         spack_install_and_test(
-            'icon @2024.1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi claw=std'
+            'icon @2024.1-1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi claw=std'
         )
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -332,6 +332,7 @@ class GridToolsTest(unittest.TestCase):
 @pytest.mark.no_tsa  # Icon does not run on Tsa
 class IconTest(unittest.TestCase):
 
+    @pytest.mark.no_daint
     def test_install_2024_1_gcc(self):
         spack_install_and_test('icon @2024.1-1 %gcc')
 
@@ -344,12 +345,13 @@ class IconTest(unittest.TestCase):
         # +coupling triggers libfyaml, libxml2, netcdf-c
         # +rttov triggers rttov
         # serialization=create triggers serialbox
-        # +cdi-pio triggers libcdi-pio, yaxt
+        # +cdi-pio triggers libcdi-pio, yaxt                   (but unfortunately this is broken)
         # +emvorado triggers eccodes, hdf5, zlib
         # +eccodes-definitions triggers cosmo-eccodes-definitions
         # +mpi triggers mpi
+        # gpu=openacc+cuda triggers cuda
         spack_install_and_test(
-            'icon @2024.1-1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi'
+            'icon @2024.1-1 %nvhpc +coupling +rttov serialization=create +emvorado +mpi gpu=openacc+cuda'
         )
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
@@ -381,6 +383,7 @@ class IconTest(unittest.TestCase):
             build_on_login_node=True)
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
+    @pytest.mark.no_daint  # contains claw=std, which doesn't exist any more.
     def test_install_c2sm_test_gpu(self):
         spack_env_dev_install_and_test(
             'config/cscs/spack/v0.18.1.10/daint_gpu_nvhpc',

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -348,9 +348,8 @@ class IconTest(unittest.TestCase):
         # +emvorado triggers eccodes, hdf5, zlib
         # +eccodes-definitions triggers cosmo-eccodes-definitions
         # +mpi triggers mpi
-        # claw=std triggers claw
         spack_install_and_test(
-            'icon @2024.1-1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi claw=std'
+            'icon @2024.1-1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi'
         )
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -332,17 +332,25 @@ class GridToolsTest(unittest.TestCase):
 @pytest.mark.no_tsa  # Icon does not run on Tsa
 class IconTest(unittest.TestCase):
 
-    def test_install_2_6_6_gcc(self):
-        spack_install_and_test('icon @2.6.6 %gcc')
+    def test_install_2024_1_gcc(self):
+        spack_install_and_test('icon @2024.1 %gcc')
 
     @pytest.mark.no_daint
-    def test_install_2_6_6_nvhpc(self):
-        spack_install_and_test('icon @2.6.6 %nvhpc')
+    def test_install_2024_1_nvhpc(self):
+        spack_install_and_test('icon @2024.1 %nvhpc')
 
     @pytest.mark.no_daint  # libxml2 %nvhpc fails to build
-    def test_install_nwp_gpu(self):
+    def test_install_conditional_dependencies(self):
+        # +coupling triggers libfyaml, libxml2, netcdf-c
+        # +rttov triggers rttov
+        # serialization=create triggers serialbox
+        # +cdi-pio triggers libcdi-pio, yaxt
+        # +emvorado triggers eccodes, hdf5, zlib
+        # +eccodes-definitions triggers cosmo-eccodes-definitions
+        # +mpi triggers mpi
+        # claw=std triggers claw
         spack_install_and_test(
-            'icon @nwp-master %nvhpc +grib2 +eccodes-definitions +ecrad +art +dace gpu=openacc+cuda +mpi-gpu +realloc-buf +pgi-inlib ~aes ~jsbach ~ocean ~coupling ~rte-rrtmgp ~loop-exchange ~async-io-rma +mixed-precision'
+            'icon @2024.1 %nvhpc +coupling +rttov serialization=create +cdi-pio +emvorado +mpi claw=std'
         )
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -357,18 +357,18 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_cpu_gcc(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.10/daint_cpu_gcc',
+            'config/cscs/spack/v0.20.1.4/daint_cpu_gcc',
             'git@github.com:C2SM/icon.git',
-            'icon-2.6.6.2',
+            '2024.01',
             'icon',
             build_on_login_node=True)
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_cpu_nvhpc_out_of_source(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.10/daint_cpu_nvhpc',
+            'config/cscs/spack/v0.20.1.4/daint_cpu_nvhpc',
             'git@github.com:C2SM/icon.git',
-            'icon-2.6.6.2',
+            '2024.01',
             'icon',
             out_of_source=True,
             build_on_login_node=True)
@@ -376,19 +376,18 @@ class IconTest(unittest.TestCase):
     @pytest.mark.no_balfrin  # config file does not exist for this machine
     def test_install_c2sm_test_cpu(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.10/daint_cpu_nvhpc',
+            'config/cscs/spack/v0.20.1.4/daint_cpu_nvhpc',
             'git@github.com:C2SM/icon.git',
-            'icon-2.6.6.2',
+            '2024.01',
             'icon',
             build_on_login_node=True)
 
     @pytest.mark.no_balfrin  # config file does not exist for this machine
-    @pytest.mark.no_daint  # contains claw=std, which doesn't exist any more.
     def test_install_c2sm_test_gpu(self):
         spack_env_dev_install_and_test(
-            'config/cscs/spack/v0.18.1.10/daint_gpu_nvhpc',
+            'config/cscs/spack/v0.20.1.4/daint_gpu_nvhpc',
             'git@github.com:C2SM/icon.git',
-            'icon-2.6.6.2',
+            '2024.01',
             'icon',
             build_on_login_node=True)
 


### PR DESCRIPTION
Replaces icon-2.6.6 with icon-2024.01-1.
Adds variants nwp, art-gpl and comin.
Removes variants edmf and claw.
Deactivates test for `icon @2024.1-1 %gcc` on daint because it fails.
Replaces test of `icon @nwp-master` with a test of the conditional dependencies of of icon.