### PR TITLE
Remove custom versions from dev-build

### DIFF
--- a/.github/workflows/deploy_docs_to_latest.yml
+++ b/.github/workflows/deploy_docs_to_latest.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Build docs
         uses: C2SM/sphinx-action@sphinx-latest
         with:
-          pre-build-command: "pip install sphinx_rtd_theme && pip install sphinx-copybutton"
           build-command: "sphinx-build -b html . _build"
           docs-folder: "docs/"
       - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_docs_to_tag.yml
+++ b/.github/workflows/deploy_docs_to_tag.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Build docs
         uses: C2SM/sphinx-action@sphinx-latest
         with:
-          pre-build-command: "pip install sphinx_rtd_theme && pip install sphinx-copybutton"
           build-command: "sphinx-build -b html . _build"
           docs-folder: "docs/"
       - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Build docs
         uses: C2SM/sphinx-action@sphinx-latest
         with:
-          pre-build-command: "pip install sphinx_rtd_theme && pip install sphinx-copybutton"
           build-command: "sphinx-build -b html . _build"
           docs-folder: "docs/"
 

--- a/docs/C2SMGuidelines.rst
+++ b/docs/C2SMGuidelines.rst
@@ -87,12 +87,7 @@ Using the wrong version suffix may break your code.
 
 ..  tip::
     To circumvent the above conflict, you can keep your executable alive in your source folder,
-    but uninstall it with Spack using ``spack uninstall <your cosmo spec>``.
-    Another option is to use a different string in ``@<string>`` for every flavor you build.
-    For example, ``spack dev-build icon @cpu``, ``spack dev-build icon @gpu``,
-    ``spack dev-build icon @my-new-feature`` etc. 
-    Then, they will all coexist and you can individually ``spack load icon @my-new-feature``
-    or uninstall and rebuild them.
+    but omit the installation phase using ``spack install --until build <your cosmo spec>``.
 
 Running
 ^^^^^^^

--- a/docs/C2SMGuidelines.rst
+++ b/docs/C2SMGuidelines.rst
@@ -74,7 +74,8 @@ In order to install software with ``spack dev-build``, one needs a
 local source code.  Spack will then compile the code as it is locally
 present. Contrary to ``spack install``, the version suffix
 (``@master``, ``@v2.7.9``, etc.) does not have any effect on the code version compiled,
-since spack will always use the local source.
+since Spack will always use the local source.
+
 Nonetheless, it is important to use the correct version suffix, i.e. ``c2sm-master``
 for all your COSMO versions that build on top of the ``c2sm-master`` branch.
 The same applies to ``c2sm-features`` etc.
@@ -87,7 +88,7 @@ Using the wrong version suffix may break your code.
 
 ..  tip::
     To circumvent the above conflict, you can keep your executable alive in your source folder,
-    but omit the installation phase using ``spack install --until build <your cosmo spec>``.
+    but omit the installation phase using ``spack dev-build --until build <your_spec>``.
 
 Running
 ^^^^^^^

--- a/docs/CodeDevelopment.rst
+++ b/docs/CodeDevelopment.rst
@@ -14,7 +14,7 @@ Enter the root of your source repository and execute:
 
 .. code-block:: console
 
-    $ spack dev-build  <package> @develop <variant>
+    $ spack dev-build --until build <package> @<version>
 
 This will install the package as is. The downside of this approach is that
 you need to go through all phases of a package build.

--- a/docs/CodeDevelopment.rst
+++ b/docs/CodeDevelopment.rst
@@ -16,7 +16,7 @@ Enter the root of your source repository and execute:
 
     $ spack dev-build --until build <package> @<version>
 
-This will install the package as is. The downside of this approach is that
+This will build the package as is. The downside of this approach is that
 you need to go through all phases of a package build.
 
 Dev-build in combination with build-env

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,21 @@
+# Makefile for Sphinx documentation
+
+SPHINXOPTS    = -c ./
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+.PHONY: help clean html
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+
+clean:
+	rm -rf $(BUILDDIR)/*
+
+html:
+	$(SPHINXBUILD) -b html $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'C2SM Spack'
-copyright = '2020-2023, C2SM'
+copyright = '2020-2024, C2SM'
 author = 'Spack Administrators'
 
 # -- General configuration ---------------------------------------------------
@@ -48,12 +48,7 @@ copybutton_prompt_is_regexp = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-#html_theme = 'groundwork'
-#html_theme_path, html_theme, needs_sphinx = set_psphinxtheme('p-green')
-#html_theme = 'karma_sphinx_theme'
 html_theme = 'sphinx_rtd_theme'
-#html_theme = 'p-main_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,6 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['static']
+#html_static_path = ['static']
 
 todo_include_todos = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-psphinxTheme
-karma-sphinx-theme
+sphinx
+sphinx_rtd_theme
+sphinx-copybutton


### PR DESCRIPTION
Fixes https://github.com/C2SM/spack-c2sm/issues/912

- [x] Adapt instructions for using version suffixes with `dev-build`
- [x] Clean-up `conf.py` 
- [x] Add Makefile to build HTML docs locally (and thus enable .rst previews in VS Code)
- [x] Update `requirements.txt` and remove manual installation of packages in GitHub actions