### PR TITLE
[Oasis] add patch to fix broken makefile in 4.0

### DIFF
--- a/repos/c2sm/packages/oasis/package.py
+++ b/repos/c2sm/packages/oasis/package.py
@@ -33,6 +33,8 @@ class Oasis(MakefilePackage):
         'rename mct modules xxx as xxx_oasis to solve conflict with other mct instance at runtime'
     )
 
+    patch('patches/patch.PSMILE_add_timer_as_dep_of_string', when='@4.0')
+
     build_directory = 'util/make_dir'
 
     makefile_file = 'TopMakefileOasis3'

--- a/repos/c2sm/packages/oasis/patches/patch.PSMILE_add_timer_as_dep_of_string
+++ b/repos/c2sm/packages/oasis/patches/patch.PSMILE_add_timer_as_dep_of_string
@@ -1,0 +1,13 @@
+diff --git a/lib/psmile/src/Makefile b/lib/psmile/src/Makefile
+index 50086e0d..94762839 100755
+--- a/lib/psmile/src/Makefile
++++ b/lib/psmile/src/Makefile
+@@ -65,7 +65,7 @@ mod_oasis_mpi.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o mod_oasis_ti
+ mod_oasis_reprosum.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \
+         mod_oasis_timer.o shr_reprosumx86.o mod_oasis_mpi.o
+ mod_oasis_string.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \
+-        mod_oasis_parameters.o
++        mod_oasis_parameters.o mod_oasis_timer.o
+ mod_oasis_namcouple.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \
+         mod_oasis_parameters.o mod_oasis_mpi.o mod_oasis_string.o
+ mod_oasis_part.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \


### PR DESCRIPTION
PSMILE makefile has wrong object deps. Only shows up for GCC compiler, hence not an issue so far.
With moving COSMO and OASIS to Euler this error poped up.
```patch
diff --git a/lib/psmile/src/Makefile b/lib/psmile/src/Makefile                                                                    
index 50086e0d..94762839 100755                                                                                                   
--- a/lib/psmile/src/Makefile                                                                                                     
+++ b/lib/psmile/src/Makefile                                                                                                     
@@ -65,7 +65,7 @@ mod_oasis_mpi.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o mod_oasis_ti                                
 mod_oasis_reprosum.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \                                                       
    |   |mod_oasis_timer.o shr_reprosumx86.o mod_oasis_mpi.o                                                                      
 mod_oasis_string.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \                                                         
-        mod_oasis_parameters.o                                                                                                   
+        mod_oasis_parameters.o mod_oasis_timer.o                                                                                 
 mod_oasis_namcouple.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \                                                      
    |   |mod_oasis_parameters.o mod_oasis_mpi.o mod_oasis_string.o                                                                
 mod_oasis_part.o: mod_oasis_kinds.o mod_oasis_data.o mod_oasis_sys.o \
```