### PR TITLE
Prepare Daint shutdown

### DIFF
--- a/repos/c2sm/packages/int2lm/package.py
+++ b/repos/c2sm/packages/int2lm/package.py
@@ -60,7 +60,7 @@ class Int2lm(MakefilePackage):
         msg=
         'int2lm-org is currently broken with pollen, set variant pollen=False')
 
-    conflicts('%cce',msg='cce compiler not supported for int2lm')
+    conflicts('%cce', msg='cce compiler not supported for int2lm')
 
     build_directory = 'TESTSUITE'
 
@@ -117,7 +117,7 @@ class Int2lm(MakefilePackage):
             env.set('LD', 'pgf90 -D__PGI_FORTRAN__')
         elif self.compiler.name == 'nvhpc':
             env.set('F90', self.spec['mpi'].mpifc + '  -D__PGI_FORTRAN__')
-            env.set('LD', self.spec['mpi'].mpifc+ '  -D__PGI_FORTRAN__')
+            env.set('LD', self.spec['mpi'].mpifc + '  -D__PGI_FORTRAN__')
         else:
             env.set('F90', self.spec['mpi'].mpifc)
             env.set('LD', self.spec['mpi'].mpifc)

--- a/repos/c2sm/packages/int2lm/package.py
+++ b/repos/c2sm/packages/int2lm/package.py
@@ -60,6 +60,8 @@ class Int2lm(MakefilePackage):
         msg=
         'int2lm-org is currently broken with pollen, set variant pollen=False')
 
+    conflicts('%cce',msg='cce compiler not supported for int2lm')
+
     build_directory = 'TESTSUITE'
 
     def setup_build_environment(self, env):
@@ -108,21 +110,14 @@ class Int2lm(MakefilePackage):
         if self.spec['mpi'].name == 'openmpi':
             env.set('MPIL', '-L' + self.spec['mpi'].prefix + ' -lmpi_mpifh')
             env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
-        else:
-            env.set('MPII', '-I' + self.spec['mpi'].prefix + '/include')
-            if self.compiler.name != 'gcc':
-                env.set('MPIL', '-L' + self.spec['mpi'].prefix + ' -lmpich')
 
         # Compiler & linker variables
         if self.compiler.name == 'pgi':
             env.set('F90', 'pgf90 -D__PGI_FORTRAN__')
             env.set('LD', 'pgf90 -D__PGI_FORTRAN__')
         elif self.compiler.name == 'nvhpc':
-            env.set('F90', 'nvfortran -D__PGI_FORTRAN__')
-            env.set('LD', 'nvfortran -D__PGI_FORTRAN__')
-        elif self.compiler.name == 'cce':
-            env.set('F90', 'ftn -D__CRAY_FORTRAN__')
-            env.set('LD', 'ftn -D__CRAY_FORTRAN__')
+            env.set('F90', self.spec['mpi'].mpifc + '  -D__PGI_FORTRAN__')
+            env.set('LD', self.spec['mpi'].mpifc+ '  -D__PGI_FORTRAN__')
         else:
             env.set('F90', self.spec['mpi'].mpifc)
             env.set('LD', self.spec['mpi'].mpifc)

--- a/repos/c2sm/packages/libgrib1/package.py
+++ b/repos/c2sm/packages/libgrib1/package.py
@@ -35,9 +35,6 @@ class Libgrib1(MakefilePackage):
     version('master', branch='master')
     version('22-01-2020', commit='3d3db9a9a090f6798c2fd4290c271dd58ff694e0')
 
-    # conflicts('@22-01-2020', when='%gcc@11.3.0')
-    # conflicts('@22-01-2020', when='%nvhpc@22.7')
-
     def edit(self, spec, prefix):
         _makefile_name = 'Makefile.linux'
         if self.compiler.name == 'gcc':
@@ -57,6 +54,11 @@ class Libgrib1(MakefilePackage):
             MakeFileFilter.filter('LIBDIR   =.*',
                                   'LIBDIR   = {0}/lib'.format(stage_path))
             options = ['-f', self._makefile_name]
+
+            if self.compiler.name in ('nvhpc'):
+                MakeFileFilter.filter('pgf90', 'nvfortran')
+                MakeFileFilter.filter('pgcc', 'nvc')
+
             make(*options)
 
     def install(self, spec, prefix):

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -176,7 +176,7 @@ def icon_env_test(spack_env: str, out_of_source: bool = False):
         shutil.copytree(os.path.join(unique_folder, 'config'),
                         os.path.join(build_dir, 'config'))
         unique_folder = build_dir
-        log_filename+= '_out_of_source'
+        log_filename += '_out_of_source'
 
     log_with_spack('spack install -n -v',
                    'system_test',

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -169,14 +169,15 @@ def icon_env_test(spack_env: str, out_of_source: bool = False):
         check=True,
         shell=True)
 
+    log_filename = sanitized_filename(spack_env)
     if out_of_source:
         build_dir = os.path.join(unique_folder, 'build')
         os.makedirs(build_dir, exist_ok=True)
         shutil.copytree(os.path.join(unique_folder, 'config'),
                         os.path.join(build_dir, 'config'))
         unique_folder = build_dir
+        log_filename+= '_out_of_source'
 
-    log_filename = sanitized_filename(spack_env) + '_out_of_source'
     log_with_spack('spack install -n -v',
                    'system_test',
                    log_filename,

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -82,10 +82,9 @@ def test_install_cosmo_eccodes_definitions_version(version):
 
 
 @pytest.mark.no_tsa
-@pytest.mark.no_balfrin
 @pytest.mark.cosmo
 def test_install_cosmo_6_0():
-    spack_install(f'cosmo@6.0', test_root=False)
+    spack_install(f'cosmo@6.0%nvhpc', test_root=False)
 
 
 @pytest.mark.eccodes
@@ -242,7 +241,6 @@ def test_install_int2ml_version_3_00_gcc():
 
 
 @pytest.mark.int2lm
-@pytest.mark.no_balfrin  # fails because libgrib1 master fails
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
     spack_install(
         f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}'
@@ -284,7 +282,6 @@ def test_install_default_onnx_runtime():
     spack_install('onnx-runtime')
 
 
-@pytest.mark.no_balfrin  # Coupling only needed on Daint
 @pytest.mark.no_tsa  # Coupling only needed on Daint
 @pytest.mark.oasis
 def test_install_oasis_version_4_0_nvhpc():

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -243,7 +243,8 @@ def test_install_int2ml_version_3_00_gcc():
 @pytest.mark.int2lm
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
     spack_install(
-        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}', test_root='balfrin' not in machine_name())
+        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}',
+        test_root='balfrin' not in machine_name())
 
 
 @pytest.mark.no_tsa  # Test is too expensive. It takes over 5h.

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -1,11 +1,9 @@
-import unittest
 import pytest
 import subprocess
 import sys
 import os
 import uuid
 import shutil
-from pathlib import Path
 import inspect
 
 spack_c2sm_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -257,10 +255,9 @@ def test_install_libcdi_pio_default():
     spack_install('libcdi-pio')
 
 
-@pytest.mark.no_balfrin  # This fails with "BOZ literal constant at (1) cannot appear in an array constructor". https://gcc.gnu.org/onlinedocs/gfortran/BOZ-literal-constants.html
 @pytest.mark.libgrib1
-def test_install_libgrib1_22_01_2020():
-    spack_install('libgrib1 @22-01-2020')
+def test_install_libgrib1_22_01_2020_nvhpc():
+    spack_install(f'libgrib1 @22-01-2020%{nvidia_compiler}')
 
 
 @pytest.mark.makedepf90

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -251,7 +251,7 @@ def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
 @pytest.mark.int2lm
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions_serial():
     spack_install(
-        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler} ~parallel',
+        f'int2lm @int2lm-3.00 %{nvidia_compiler} ~parallel ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}',
         test_root=False)
 
 

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -240,10 +240,17 @@ def test_install_int2ml_version_3_00_gcc():
     spack_install('int2lm @int2lm-3.00 %gcc', test_root=False)
 
 
+@pytest.mark.no_balfrin  # ld undefined reference to mpi_recv_
 @pytest.mark.int2lm
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
     spack_install(
         f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}'
+    )
+
+@pytest.mark.int2lm
+def test_install_int2lm_version_3_00_nvhpc_fixed_definitions_serial():
+    spack_install(
+        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler} ~parallel', test_root=False
     )
 
 
@@ -282,7 +289,7 @@ def test_install_default_onnx_runtime():
     spack_install('onnx-runtime')
 
 
-@pytest.mark.no_tsa  # Coupling only needed on Daint
+@pytest.mark.no_tsa  # Coupling not needed on Tsa
 @pytest.mark.oasis
 def test_install_oasis_version_4_0_nvhpc():
     spack_install('oasis @4.0 %nvhpc')

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -240,12 +240,10 @@ def test_install_int2ml_version_3_00_gcc():
     spack_install('int2lm @int2lm-3.00 %gcc', test_root=False)
 
 
-@pytest.mark.no_balfrin  # ld undefined reference to mpi_recv_
 @pytest.mark.int2lm
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
     spack_install(
-        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}'
-    )
+        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}', test_root='balfrin' not in machine_name())
 
 
 @pytest.mark.no_tsa  # Test is too expensive. It takes over 5h.

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -248,13 +248,6 @@ def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
     )
 
 
-@pytest.mark.int2lm
-def test_install_int2lm_version_3_00_nvhpc_fixed_definitions_serial():
-    spack_install(
-        f'int2lm @int2lm-3.00 %{nvidia_compiler} ~parallel ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}',
-        test_root=False)
-
-
 @pytest.mark.no_tsa  # Test is too expensive. It takes over 5h.
 @pytest.mark.libcdi_pio
 def test_install_libcdi_pio_default():

--- a/test/system_test.py
+++ b/test/system_test.py
@@ -247,11 +247,12 @@ def test_install_int2lm_version_3_00_nvhpc_fixed_definitions():
         f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler}'
     )
 
+
 @pytest.mark.int2lm
 def test_install_int2lm_version_3_00_nvhpc_fixed_definitions_serial():
     spack_install(
-        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler} ~parallel', test_root=False
-    )
+        f'int2lm @int2lm-3.00 %{nvidia_compiler} ^cosmo-eccodes-definitions@2.19.0.7%{nvidia_compiler} ~parallel',
+        test_root=False)
 
 
 @pytest.mark.no_tsa  # Test is too expensive. It takes over 5h.


### PR DESCRIPTION
Activate tests on Balfrin that are still needed for users on Euler to make sure the recipes keep working.