### PR TITLE
Icontools: Remove version restriction of eccodes

### DIFF
--- a/repos/c2sm/packages/icontools/package.py
+++ b/repos/c2sm/packages/icontools/package.py
@@ -46,7 +46,7 @@ class Icontools(AutotoolsPackage):
         'mpi',
         type=('build', 'link', 'run'),
     )
-    depends_on('eccodes@2.19.0 +fortran ~aec', type=('build', 'link', 'run'))
+    depends_on('eccodes +fortran ~aec', type=('build', 'link', 'run'))
     depends_on('jasper@1.900.1', type=('build', 'link'))
 
     variant(


### PR DESCRIPTION
To process data from DWD, which uses eccodes 2.25.0, MeteoSwiss needs to set that version of eccodes.