### PR TITLE
Icon: Remove BB specific parts

### DIFF
--- a/repos/c2sm/packages/icon/package.py
+++ b/repos/c2sm/packages/icon/package.py
@@ -277,13 +277,6 @@ class Icon(AutotoolsPackage, CudaPackage):
     out_of_source_build = False
     out_of_source_configure_directory = ''
 
-    # patch_libtool is a function from Autotoolspackage.
-    # For BB we cannot use it because it finds all files
-    # named "libtool". spack-c2sm is cloned into icon-repo,
-    # therefore this function detects not only "libtool" files, but
-    # also the folder where libtool package itself is installed.
-    patch_libtool = False
-
     def setup_build_environment(self, env):
         # help cmake to build dsl-stencils
         if 'none' not in self.spec.variants['dsl'].value:
@@ -649,12 +642,6 @@ class Icon(AutotoolsPackage, CudaPackage):
                 f'The value "{arg}" for the extra_config_args variant conflicts '
                 f'with the existing variant {variant_from_arg}. Set this variant instead.'
             )
-
-    def check(self):
-        # By default "check" calls make with targets "check" and "test".
-        # This testing is beyond the scope of BuildBot test at CSCS.
-        # Therefore override this function, saves a lot of time too.
-        pass
 
     @run_after('install')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
Removes BuildBot specific workarounds, so the GLORI project can make use of all features of spack.
Removes `patch_libtool = False` because the GLORI project wants libtools patched.
Removes `def check(self): pass` so the GLORI project can run tests of icon via spack.
IMHO, if BB clones spack-c2sm into its own repo and this is causing problems, then this is a BB problem, not a package problem and BB should just clone spack-c2sm to somewhere else.