### PR TITLE
Fix JasPer for Icontools

### DIFF
--- a/repos/c2sm/packages/icontools/package.py
+++ b/repos/c2sm/packages/icontools/package.py
@@ -47,7 +47,7 @@ class Icontools(AutotoolsPackage):
         type=('build', 'link', 'run'),
     )
     depends_on('eccodes +fortran ~aec', type=('build', 'link', 'run'))
-    depends_on('jasper@1.900.1', type=('build', 'link'))
+    depends_on('jasper@1.900.1-aarch64+aarch64', type=('build', 'link'))
 
     variant(
         'slave',

--- a/repos/c2sm/packages/icontools/package.py
+++ b/repos/c2sm/packages/icontools/package.py
@@ -47,7 +47,7 @@ class Icontools(AutotoolsPackage):
         type=('build', 'link', 'run'),
     )
     depends_on('eccodes +fortran ~aec', type=('build', 'link', 'run'))
-    depends_on('jasper@1.900.1-aarch64+aarch64', type=('build', 'link'))
+    depends_on('jasper@1.900.1', type=('build', 'link'))
 
     variant(
         'slave',

--- a/repos/c2sm/packages/jasper/fix_alpha_channel_assert_fail.patch
+++ b/repos/c2sm/packages/jasper/fix_alpha_channel_assert_fail.patch
@@ -1,0 +1,25 @@
+diff --git a/src/libjasper/jpc/jpc_dec.c b/src/libjasper/jpc/jpc_dec.c
+index fa72a0e..1f4845f 100644
+--- a/src/libjasper/jpc/jpc_dec.c
++++ b/src/libjasper/jpc/jpc_dec.c
+@@ -1069,12 +1069,18 @@ static int jpc_dec_tiledecode(jpc_dec_t *dec, jpc_dec_tile_t *tile)
+	/* Apply an inverse intercomponent transform if necessary. */
+	switch (tile->cp->mctid) {
+	case JPC_MCT_RCT:
+-		assert(dec->numcomps == 3);
++		if (dec->numcomps != 3 && dec->numcomps != 4) {
++			jas_eprintf("bad number of components (%d)\n", dec->numcomps);
++			return -1;
++		}
+		jpc_irct(tile->tcomps[0].data, tile->tcomps[1].data,
+		  tile->tcomps[2].data);
+		break;
+	case JPC_MCT_ICT:
+-		assert(dec->numcomps == 3);
++		if (dec->numcomps != 3 && dec->numcomps != 4) {
++			jas_eprintf("bad number of components (%d)\n", dec->numcomps);
++			return -1;
++		}
+		jpc_iict(tile->tcomps[0].data, tile->tcomps[1].data,
+		  tile->tcomps[2].data);
+		break;

--- a/repos/c2sm/packages/jasper/package.py
+++ b/repos/c2sm/packages/jasper/package.py
@@ -22,7 +22,7 @@ class Jasper(Package):
     variant("jpeg", default=True, description="Enable the use of the JPEG library")
     variant("opengl", default=False, description="Enable the use of the OpenGL and GLUT libraries")
     variant("shared", default=True, description="Enable the building of shared libraries")
-    variant("aarch64", default=False, description="Build for aarch64 architecture")
+    variant("aarch64", default=True, description="Build for aarch64 architecture")
     variant(
         "build_type",
         default="Release",

--- a/repos/c2sm/packages/jasper/package.py
+++ b/repos/c2sm/packages/jasper/package.py
@@ -1,0 +1,114 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Jasper(Package):
+    """Library for manipulating JPEG-2000 images"""
+
+    homepage = "https://www.ece.uvic.ca/~frodo/jasper/"
+    url = "https://github.com/jasper-software/jasper/archive/version-2.0.32.tar.gz"
+
+    version("3.0.3", sha256="1b324f7746681f6d24d06fcf163cf3b8ae7ac320adc776c3d611b2b62c31b65f")
+    version("2.0.32", sha256="a3583a06698a6d6106f2fc413aa42d65d86bedf9a988d60e5cfa38bf72bc64b9")
+    version("2.0.31", sha256="d419baa2f8a6ffda18472487f6314f0f08b673204723bf11c3a1f5b3f1b8e768")
+    version("2.0.16", sha256="f1d8b90f231184d99968f361884e2054a1714fdbbd9944ba1ae4ebdcc9bbfdb1")
+    version("2.0.14", sha256="85266eea728f8b14365db9eaf1edc7be4c348704e562bb05095b9a077cf1a97b")
+    version("1.900.1", sha256="c2b03f28166f9dc8ae434918839ae9aa9962b880fcfd24eebddd0a2daeb9192c")
+
+    variant("jpeg", default=True, description="Enable the use of the JPEG library")
+    variant("opengl", default=False, description="Enable the use of the OpenGL and GLUT libraries")
+    variant("shared", default=True, description="Enable the building of shared libraries")
+    variant("aarch64", default=False, description="Build for aarch64 architecture")
+    variant(
+        "build_type",
+        default="Release",
+        description="CMake build type",
+        values=("Debug", "Release"),
+    )
+
+    depends_on("cmake@2.8.11:", type="build", when="@2:")
+    depends_on("cmake@3.12:", type="build", when="@3:")
+    depends_on("jpeg", when="+jpeg")
+    depends_on("gl", when="+opengl")
+
+    # invalid compilers flags
+    conflicts("@2.0.0:2", when="%nvhpc")
+
+    # Fixes a bug where an assertion fails when certain JPEG-2000
+    # files with an alpha channel are processed.
+    # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=469786
+    patch("fix_alpha_channel_assert_fail.patch", when="@1.900.1")
+
+    def cmake_args(self):
+        spec = self.spec
+        args = std_cmake_args
+        args.append("-DJAS_ENABLE_DOC=false")
+
+        if "+jpeg" in spec:
+            args.append("-DJAS_ENABLE_LIBJPEG=true")
+        else:
+            args.append("-DJAS_ENABLE_LIBJPEG=false")
+
+        if "+opengl" in spec:
+            args.append("-DJAS_ENABLE_OPENGL=true")
+        else:
+            args.append("-DJAS_ENABLE_OPENGL=false")
+
+        if "+shared" in spec:
+            args.append("-DJAS_ENABLE_SHARED=true")
+        else:
+            args.append("-DJAS_ENABLE_SHARED=false")
+
+        return args
+
+    def configure_args(self):
+        spec = self.spec
+        args = ["--prefix={0}".format(self.prefix)]
+
+        if "+jpeg" in spec:
+            args.append("--enable-libjpeg")
+        else:
+            args.append("--disable-libjpeg")
+
+        if "+opengl" in spec:
+            args.append("--enable-opengl")
+        else:
+            args.append("--disable-opengl")
+
+        if "+shared" in spec:
+            args.append("--enable-shared")
+        else:
+            args.append("--disable-shared")
+
+        if "build_type=Debug" in spec:
+            args.append("--enable-debug")
+        else:
+            args.append("--disable-debug")
+
+        if "+aarch64" in spec:
+            args.append("--build=aarch64-unknown-linux-gnu")
+
+        return args
+
+    @when("@2:")
+    def install(self, spec, prefix):
+        with working_dir("spack-build", create=True):
+            cmake("..", *self.cmake_args())
+            make()
+            if self.run_tests:
+                make("test")
+            make("install")
+
+    @when("@:1")
+    def install(self, spec, prefix):
+        configure(*self.configure_args())
+        make()
+        if self.run_tests:
+            make("check")
+        make("install")
+        if self.run_tests:
+            make("installcheck")


### PR DESCRIPTION
This change adds the [JasPer](https://www.ece.uvic.ca/~frodo/jasper/) library into the `spack-c2sm` project, merely to add a variant for building on `aarch64` which, at least for me, didn't work out of the box.

As you can see below, for reasons unclear to me, we need a double pass of `spack install icontools` because otherwise `openmpi` fails to build. But that's not the topic of this PR.

I've made the `aarch64` variant the default version, which should suffice on Alps for now.

Please verify that you can reproduce the issue that this PR solves, too.

```
(base) ekoene@santis-ln001:/capstor/scratch/cscs/ekoene/tmp> CLUSTER_NAME=todi uenv start icon-wcp
(base) ekoene@santis-ln001:/capstor/scratch/cscs/ekoene/tmp> . spack-c2sm/setup-env.sh /user-environment/
Spack configured with upstream /user-environment/.
(base) ekoene@santis-ln001:/capstor/scratch/cscs/ekoene/tmp> spack install icontools@c2sm-master%gcc
[+] /usr (external autoconf-2.69-oxar3yab7bb47sxf52qqbq555muwwga7)
[+] /usr (external perl-5.26.1-jxi7g4iwyosifl53aft7g7sgpuo2qf33)
[+] /usr (external curl-8.0.1-ugo4qtzxc2dki7ir3l54w2ksrh63ayzh)
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/ncurses-6.4-iv6mwhw6gkc7cz7criwqhp7tazsukuwx
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/zlib-ng-2.1.4-43zfkjowmqng5ttdtqtknbzj4o3fv6jr
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gmake-4.4.1-vzomhfqre2ukrurdztruakojdxf4z5uu
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gnuconfig-2022-09-17-xpuu2muvlqpq6aacbmywusj2mmzpiw6g
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libjpeg-turbo-3.0.0-iwktrx65evwkatxoxqjonfswvuob6yzc
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/bzip2-1.0.8-qa5diypihzopxxc3che7gkfwzepzqvyz
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/lz4-1.9.4-obnimcss2ifr3gb5lxkktkc7k3v45ill
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/snappy-1.1.10-zcf6cbbgzr5vfuk27nzrbxqq4z7cdxyw
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/zstd-1.5.5-kcvdyk3zk4nc7eylk4xed2ytqvtpmfbb
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libaec-1.0.6-mkmj4wih4kdfi3yl3he43ic2ooefysb2
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/cmake-3.27.7-j2m2jyxcinpshbyulfxfthsa2t2kx4rn
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/pigz-2.7-2d4r6mxlafbh76lyusir4j4mwy4wjjzd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/openssl-3.1.3-klgt2v2wwmdeh6lzffaplhletsbhhdck
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/automake-1.16.5-3h5a5xe5j2v5fvhz3yh4r27fnmthq673
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libtool-2.4.7-jxlpxrk2ss6gs36waiwjshix6sl3wxiy
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/pkgconf-1.9.5-6wajaqmcehgljwoo7zfhxtmqxhridfca
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/xz-5.4.1-zzcvonp6lohwukm2262x55wgmxwe7lnt
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libsigsegv-2.14-3xhstimclute2hkqzov7rlt4rp6vqbry
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libxcrypt-4.4.35-htffpvr5wewidzm4tgobnpartr257bdd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/findutils-4.9.0-oyuwhk2fj3tuiu5smxpx2qysvnvqoedp
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libiconv-1.17-zr7yi6s3n33bonlj2xqg5v5scaiwat36
==> Installing jasper-1.900.1-nu7itisyyd6tdgrwtckybljdf6vqredw [25/48]
==> No binary for jasper-1.900.1-nu7itisyyd6tdgrwtckybljdf6vqredw found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/c2/c2b03f28166f9dc8ae434918839ae9aa9962b880fcfd24eebddd0a2daeb9192c.tar.gz
==> Applied patch /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/repos/c2sm/packages/jasper/fix_alpha_channel_assert_fail.patch
==> jasper: Executing phase: 'install'
==> jasper: Successfully installed jasper-1.900.1-nu7itisyyd6tdgrwtckybljdf6vqredw
  Stage: 0.64s.  Install: 20.86s.  Post-install: 0.16s.  Total: 21.95s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/jasper-1.900.1-nu7itisyyd6tdgrwtckybljdf6vqredw
==> Installing openjpeg-2.3.1-dfzvv5pw3rhqg2x6bzey57wmym32eyqg [26/48]
==> No binary for openjpeg-2.3.1-dfzvv5pw3rhqg2x6bzey57wmym32eyqg found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/63/63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9.tar.gz
==> No patches needed for openjpeg
==> openjpeg: Executing phase: 'cmake'
==> openjpeg: Executing phase: 'build'
==> openjpeg: Executing phase: 'install'
==> openjpeg: Successfully installed openjpeg-2.3.1-dfzvv5pw3rhqg2x6bzey57wmym32eyqg
  Stage: 2.88s.  Cmake: 4.23s.  Build: 2.92s.  Install: 0.24s.  Post-install: 0.12s.  Total: 10.63s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/openjpeg-2.3.1-dfzvv5pw3rhqg2x6bzey57wmym32eyqg
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/c-blosc-1.21.5-qq5mdx7yid2hxxdke5yefbaj2nu5mqh5
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/numactl-2.0.14-di4gffn44hyhqjs3psi2xtkpxnm6oz3e
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libpciaccess-0.17-jjii4uwlk3fcvv5jspxvk3aikzqgtqqr
==> Installing libevent-2.1.12-4tg3nalvruhrkva7q7t3xee4t5hks4bm [30/48]
==> No binary for libevent-2.1.12-4tg3nalvruhrkva7q7t3xee4t5hks4bm found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/92/92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb.tar.gz
==> Ran patch() for libevent
==> libevent: Executing phase: 'autoreconf'
==> libevent: Executing phase: 'configure'
==> libevent: Executing phase: 'build'
==> libevent: Executing phase: 'install'
==> libevent: Successfully installed libevent-2.1.12-4tg3nalvruhrkva7q7t3xee4t5hks4bm
  Stage: 0.84s.  Autoreconf: 3.87s.  Configure: 12.23s.  Build: 3.01s.  Install: 0.60s.  Post-install: 0.24s.  Total: 21.18s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/libevent-2.1.12-4tg3nalvruhrkva7q7t3xee4t5hks4bm
==> Installing hdf5-1.14.3-c65v3gtbiyoyspp745ux7ukj2aa2oc7c [31/48]
==> No binary for hdf5-1.14.3-c65v3gtbiyoyspp745ux7ukj2aa2oc7c found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/09/09cdb287aa7a89148c1638dd20891fdbae08102cf433ef128fd345338aa237c7.tar.gz
==> Ran patch() for hdf5
==> hdf5: Executing phase: 'cmake'
==> hdf5: Executing phase: 'build'
==> hdf5: Executing phase: 'install'
==> hdf5: Successfully installed hdf5-1.14.3-c65v3gtbiyoyspp745ux7ukj2aa2oc7c
  Stage: 12.69s.  Cmake: 20.72s.  Build: 21.05s.  Install: 2.26s.  Post-install: 0.53s.  Total: 57.57s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/hdf5-1.14.3-c65v3gtbiyoyspp745ux7ukj2aa2oc7c
==> Installing libedit-3.1-20210216-w6lwp5to2uhqo7m5jo5cjqpjch7uypht [32/48]
==> No binary for libedit-3.1-20210216-w6lwp5to2uhqo7m5jo5cjqpjch7uypht found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/22/2283f741d2aab935c8c52c04b57bf952d02c2c02e651172f8ac811f77b1fc77a.tar.gz
==> No patches needed for libedit
==> libedit: Executing phase: 'autoreconf'
==> libedit: Executing phase: 'configure'
==> libedit: Executing phase: 'build'
==> libedit: Executing phase: 'install'
==> libedit: Successfully installed libedit-3.1-20210216-w6lwp5to2uhqo7m5jo5cjqpjch7uypht
  Stage: 0.34s.  Autoreconf: 0.04s.  Configure: 6.27s.  Build: 1.75s.  Install: 0.23s.  Post-install: 0.11s.  Total: 8.94s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/libedit-3.1-20210216-w6lwp5to2uhqo7m5jo5cjqpjch7uypht
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/m4-1.4.19-gee3altseiqdh4rgdf3xl5qcla33ii7y
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/tar-1.34-n4q3usgrphw5tgb2n7i52rmwjvvshrh4
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/diffutils-3.9-gpq5i7dfly6i433neqnlgdaiancl7gcd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libxml2-2.10.3-ig7ype3strik4wff3tstj3cclajudalt
==> Installing eccodes-2.25.0-pgjm4zjel7gmypnft3oyza6te364euxg [37/48]
==> No binary for eccodes-2.25.0-pgjm4zjel7gmypnft3oyza6te364euxg found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/89/8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e.tar.gz
==> No patches needed for eccodes
==> eccodes: Executing phase: 'cmake'
==> eccodes: Executing phase: 'build'
==> eccodes: Executing phase: 'install'
==> eccodes: Successfully installed eccodes-2.25.0-pgjm4zjel7gmypnft3oyza6te364euxg
  Stage: 36.99s.  Cmake: 12.09s.  Build: 30.32s.  Install: 2m 31.36s.  Post-install: 40.48s.  Total: 4m 31.51s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/eccodes-2.25.0-pgjm4zjel7gmypnft3oyza6te364euxg
==> Installing netcdf-c-4.9.2-yvo27bpftwpcq2ymo2jl2v2ibpmk4kzy [38/48]
==> No binary for netcdf-c-4.9.2-yvo27bpftwpcq2ymo2jl2v2ibpmk4kzy found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/bc/bc104d101278c68b303359b3dc4192f81592ae8640f1aee486921138f7f88cb7.tar.gz
==> Fetching https://mirror.spack.io/_source-cache/archive/01/0161eb870fdfaf61be9d70132c9447a537320342366362e76b8460c823bf95ca
==> Applied patch https://github.com/Unidata/netcdf-c/commit/f8904d5a1d89420dde0f9d2c0e051ba08d08e086.patch?full_index=1
==> netcdf-c: Executing phase: 'autoreconf'
==> netcdf-c: Executing phase: 'configure'
==> netcdf-c: Executing phase: 'build'
==> netcdf-c: Executing phase: 'install'
==> netcdf-c: Successfully installed netcdf-c-4.9.2-yvo27bpftwpcq2ymo2jl2v2ibpmk4kzy
  Stage: 5.00s.  Autoreconf: 0.00s.  Configure: 16.74s.  Build: 11.98s.  Install: 1.29s.  Post-install: 0.24s.  Total: 35.73s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/netcdf-c-4.9.2-yvo27bpftwpcq2ymo2jl2v2ibpmk4kzy
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gettext-0.22.3-c4emy5kuud3dtsdpk3lbqvm454meurpd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/cuda-12.3.0-dpv4zkhn6js7p5kvjqtf74x5suknx3t4
==> Installing netcdf-fortran-4.6.1-wt3rfcwmuudi2x2r5ldxyna2qhtkbrzb [41/48]
==> No binary for netcdf-fortran-4.6.1-wt3rfcwmuudi2x2r5ldxyna2qhtkbrzb found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/b5/b50b0c72b8b16b140201a020936aa8aeda5c79cf265c55160986cd637807a37a.tar.gz
==> No patches needed for netcdf-fortran
==> netcdf-fortran: Executing phase: 'autoreconf'
==> netcdf-fortran: Executing phase: 'configure'
==> netcdf-fortran: Executing phase: 'build'
==> netcdf-fortran: Executing phase: 'install'
==> netcdf-fortran: Successfully installed netcdf-fortran-4.6.1-wt3rfcwmuudi2x2r5ldxyna2qhtkbrzb
  Stage: 0.64s.  Autoreconf: 0.05s.  Configure: 9.26s.  Build: 28.74s.  Install: 0.36s.  Post-install: 0.21s.  Total: 39.72s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/netcdf-fortran-4.6.1-wt3rfcwmuudi2x2r5ldxyna2qhtkbrzb
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/bison-3.8.2-yy43npv27g6ldqo6daakgzlzetn6nnur
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/hwloc-2.9.1-tcfta4qzkfircj2qqk6ehcpo5vfqjqc3
==> Installing krb5-1.20.1-xtmzjdarygew36diqr7yr67kroot55kk [44/48]
==> No binary for krb5-1.20.1-xtmzjdarygew36diqr7yr67kroot55kk found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/70/704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851.tar.gz
==> Ran patch() for krb5
==> krb5: Executing phase: 'autoreconf'
==> krb5: Executing phase: 'configure'
==> krb5: Executing phase: 'build'
==> krb5: Executing phase: 'install'
==> krb5: Successfully installed krb5-1.20.1-xtmzjdarygew36diqr7yr67kroot55kk
  Stage: 7.42s.  Autoreconf: 0.30s.  Configure: 16.93s.  Build: 17.05s.  Install: 1.98s.  Post-install: 0.61s.  Total: 44.84s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/krb5-1.20.1-xtmzjdarygew36diqr7yr67kroot55kk
==> Installing pmix-5.0.1-poc2g4y6muab7an3fab7wdhxadqh7noy [45/48]
==> No binary for pmix-5.0.1-poc2g4y6muab7an3fab7wdhxadqh7noy found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/d4/d4371792d4ba4c791e1010100b4bf9a65500ababaf5ff25d681f938527a67d4a.tar.bz2
==> No patches needed for pmix
==> pmix: Executing phase: 'autoreconf'
==> pmix: Executing phase: 'configure'
==> pmix: Executing phase: 'build'
==> pmix: Executing phase: 'install'
==> pmix: Successfully installed pmix-5.0.1-poc2g4y6muab7an3fab7wdhxadqh7noy
  Stage: 3.02s.  Autoreconf: 0.24s.  Configure: 23.81s.  Build: 51.10s.  Install: 4.37s.  Post-install: 0.99s.  Total: 1m 24.00s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/pmix-5.0.1-poc2g4y6muab7an3fab7wdhxadqh7noy
==> Installing openssh-9.5p1-x7v3bpdowzkug2xgvul4zqzuecdese6l [46/48]
==> No binary for openssh-9.5p1-x7v3bpdowzkug2xgvul4zqzuecdese6l found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/f0/f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b.tar.gz
==> Ran patch() for openssh
==> openssh: Executing phase: 'autoreconf'
==> openssh: Executing phase: 'configure'
==> openssh: Executing phase: 'build'
==> openssh: Executing phase: 'install'
==> openssh: Successfully installed openssh-9.5p1-x7v3bpdowzkug2xgvul4zqzuecdese6l
  Stage: 1.87s.  Autoreconf: 0.08s.  Configure: 32.51s.  Build: 3.71s.  Install: 0.73s.  Post-install: 0.31s.  Total: 39.87s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/openssh-9.5p1-x7v3bpdowzkug2xgvul4zqzuecdese6l
==> Installing openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h [47/48]
==> No binary for openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/f7/f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415.tar.bz2
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> openmpi: Executing phase: 'configure'
==> openmpi: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

19 errors found in build log:
     5593    libtool: link: ranlib .libs/libmca_btl_tcp.a
     5594    libtool: link: ( cd ".libs" && rm -f "libmca_btl_tcp.la" && ln -s "../libmca_btl_tcp.la" "libmca_btl_tcp.la" )
     5595    make[2]: Leaving directory '/capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-src/opal/mca/btl/tcp'
     5596    Making all in mca/btl/vader
     5597    make[2]: Entering directory '/capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-src/opal/mca/btl/vader'
     5598     cd ../../../.. && /bin/sh /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-src/config/missing automake-1.15 --foreign o
             pal/mca/btl/vader/Makefile
  >> 5599    sh: config/opal_get_version.sh: No such file or directory
  >> 5600    sh: config/opal_get_version.sh: No such file or directory
  >> 5601    sh: config/opal_get_version.sh: No such file or directory
  >> 5602    sh: config/opal_get_version.sh: No such file or directory
  >> 5603    sh: config/opal_get_version.sh: No such file or directory
  >> 5604    sh: config/opal_get_version.sh: No such file or directory
  >> 5605    sh: config/opal_get_version.sh: No such file or directory
  >> 5606    sh: config/opal_get_version.sh: No such file or directory
  >> 5607    sh: config/opal_get_version.sh: No such file or directory
  >> 5608    sh: config/opal_get_version.sh: No such file or directory
  >> 5609    sh: config/opal_get_version.sh: No such file or directory
  >> 5610    sh: config/opal_get_version.sh: No such file or directory
  >> 5611    configure.ac:103: error: version mismatch.  This is Automake 1.15.1,
  >> 5612    configure.ac:103: but the definition used by this AM_INIT_AUTOMAKE
  >> 5613    configure.ac:103: comes from Automake 1.15.  You should recreate
  >> 5614    configure.ac:103: aclocal.m4 with aclocal and run automake again.
     5615    WARNING: 'automake-1.15' is probably too old.
     5616             You should only need it if you modified 'Makefile.am' or
     5617             'configure.ac' or m4 files included by 'configure.ac'.
     5618             The 'automake' program is part of the GNU Automake package:
     5619             <http://www.gnu.org/software/automake>
     5620             It also requires GNU Autoconf, GNU m4 and Perl in order to run:
     5621             <http://www.gnu.org/software/autoconf>
     5622             <http://www.gnu.org/software/m4/>
     5623             <http://www.perl.org/>
  >> 5624    make[2]: *** [Makefile:1805: Makefile.in] Error 63
     5625    make[2]: Leaving directory '/capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-src/opal/mca/btl/vader'
  >> 5626    make[1]: *** [Makefile:2387: all-recursive] Error 1
     5627    make[1]: Leaving directory '/capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-src/opal'
  >> 5628    make: *** [Makefile:1905: all-recursive] Error 1

See build log for details:
  /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack-build_stage/spack-stage-openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h/spack-build-out.txt

==> Warning: Skipping build of icontools-c2sm-master-5zc7ndoeeozjqipstyyvnckodpdaellz since openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h failed
==> Error: icontools-c2sm-master-5zc7ndoeeozjqipstyyvnckodpdaellz: Package was not installed
==> Error: Installation request failed.  Refer to reported errors for failing package(s).
(base) ekoene@santis-ln001:/capstor/scratch/cscs/ekoene/tmp> spack install icontools
[+] /usr (external autoconf-2.69-oxar3yab7bb47sxf52qqbq555muwwga7)
[+] /usr (external perl-5.26.1-jxi7g4iwyosifl53aft7g7sgpuo2qf33)
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/openjpeg-2.3.1-dfzvv5pw3rhqg2x6bzey57wmym32eyqg
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gmake-4.4.1-vzomhfqre2ukrurdztruakojdxf4z5uu
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gnuconfig-2022-09-17-xpuu2muvlqpq6aacbmywusj2mmzpiw6g
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libjpeg-turbo-3.0.0-iwktrx65evwkatxoxqjonfswvuob6yzc
[+] /usr (external m4-1.4.18-qep7waivk25sb5h3uwljvlulp3h6zel5)
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/bzip2-1.0.8-qa5diypihzopxxc3che7gkfwzepzqvyz
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/lz4-1.9.4-obnimcss2ifr3gb5lxkktkc7k3v45ill
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/snappy-1.1.10-zcf6cbbgzr5vfuk27nzrbxqq4z7cdxyw
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/zstd-1.5.5-kcvdyk3zk4nc7eylk4xed2ytqvtpmfbb
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libaec-1.0.6-mkmj4wih4kdfi3yl3he43ic2ooefysb2
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/eccodes-2.25.0-pgjm4zjel7gmypnft3oyza6te364euxg
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libxcrypt-4.4.35-htffpvr5wewidzm4tgobnpartr257bdd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libiconv-1.17-zr7yi6s3n33bonlj2xqg5v5scaiwat36
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/xz-5.4.1-zzcvonp6lohwukm2262x55wgmxwe7lnt
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libtool-2.4.7-jxlpxrk2ss6gs36waiwjshix6sl3wxiy
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/zlib-ng-2.1.4-43zfkjowmqng5ttdtqtknbzj4o3fv6jr
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/ncurses-6.4-iv6mwhw6gkc7cz7criwqhp7tazsukuwx
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/automake-1.16.5-3h5a5xe5j2v5fvhz3yh4r27fnmthq673
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/pkgconf-1.9.5-6wajaqmcehgljwoo7zfhxtmqxhridfca
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/jasper-1.900.1-nu7itisyyd6tdgrwtckybljdf6vqredw
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libpciaccess-0.17-jjii4uwlk3fcvv5jspxvk3aikzqgtqqr
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/libxml2-2.10.3-ig7ype3strik4wff3tstj3cclajudalt
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/c-blosc-1.21.5-qq5mdx7yid2hxxdke5yefbaj2nu5mqh5
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/openssl-3.1.3-klgt2v2wwmdeh6lzffaplhletsbhhdck
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/pigz-2.7-2d4r6mxlafbh76lyusir4j4mwy4wjjzd
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/numactl-2.0.14-di4gffn44hyhqjs3psi2xtkpxnm6oz3e
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/libedit-3.1-20210216-w6lwp5to2uhqo7m5jo5cjqpjch7uypht
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/hdf5-1.14.3-c65v3gtbiyoyspp745ux7ukj2aa2oc7c
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/cuda-12.3.0-dpv4zkhn6js7p5kvjqtf74x5suknx3t4
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/libevent-2.1.12-4tg3nalvruhrkva7q7t3xee4t5hks4bm
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/tar-1.34-n4q3usgrphw5tgb2n7i52rmwjvvshrh4
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/netcdf-c-4.9.2-yvo27bpftwpcq2ymo2jl2v2ibpmk4kzy
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/hwloc-2.9.1-tcfta4qzkfircj2qqk6ehcpo5vfqjqc3
[+] /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/gettext-0.22.3-c4emy5kuud3dtsdpk3lbqvm454meurpd
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/netcdf-fortran-4.6.1-wt3rfcwmuudi2x2r5ldxyna2qhtkbrzb
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/pmix-5.0.1-poc2g4y6muab7an3fab7wdhxadqh7noy
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/krb5-1.20.1-xtmzjdarygew36diqr7yr67kroot55kk
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/openssh-9.5p1-x7v3bpdowzkug2xgvul4zqzuecdese6l
==> Installing openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h [41/42]
==> No binary for openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h found: installing from source
==> Using cached archive: /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/var/spack/cache/_source-cache/archive/f7/f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415.tar.bz2
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> openmpi: Executing phase: 'configure'
==> openmpi: Executing phase: 'build'
==> openmpi: Executing phase: 'install'
==> openmpi: Successfully installed openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h
  Stage: 10.83s.  Autoreconf: 0.74s.  Configure: 2m 0.64s.  Build: 2m 58.60s.  Install: 22.55s.  Post-install: 1.54s.  Total: 5m 39.82s
[+] /capstor/scratch/cscs/ekoene/tmp/spack-c2sm/spack/opt/spack/linux-sles15-neoverse_v2/gcc-12.3.0/openmpi-4.1.6-hu3xn3vsxchfszndpdo2iytbf4u6ry6h
==> Installing icontools-2.5.2-j2qaqyr4f2x5g4xsunhllvf3nzq6txeo [42/42]
==> No binary for icontools-2.5.2-j2qaqyr4f2x5g4xsunhllvf3nzq6txeo found: installing from source
```